### PR TITLE
Enable time restrictions on crawlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ An example can be seen in the [default configuration file](./geospaas_harvesting
 
 **Top-level keys**:
 
-- **poll_interval**: The interval in seconds at which the main process checks if the running
-  harvester processes have finished executing.
+- **endless** (default: False): boolean controlling the endless harvesting mode. If True, the 
+  harvesters will be indefinitely re-run after they finish harvesting.
+- **poll_interval** (default: 600): the interval in seconds at which the main process checks if the
+  running harvester processes have finished executing.
 - **harvesters**: dictionary mapping the harvesters names to a dictionary containing their 
   properties.
 
@@ -77,6 +79,9 @@ The properties which are common to every harvester are:
   (like a web interface or API).
 
 The rest depends on the harvester and will be detailed in each harvester's documentation.
+
+- **time_range** (optional): a two-elements list containing two date strings which define a time
+  range to which the crawler will be limited.
 
 ## Design
 

--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -1,7 +1,11 @@
-"""A set of crawlers used to explore data provider interfaces and get resources URLs"""
-
+"""
+A set of crawlers used to explore data provider interfaces and get resources URLs. Each crawler
+should inherit from the Crawler class and implement the abstract methods defined in Crawler.
+"""
+import calendar
 import logging
 import re
+from datetime import datetime, timedelta
 from html.parser import HTMLParser
 
 import feedparser
@@ -39,76 +43,6 @@ class Crawler():
         return html_page
 
 
-class OpenDAPCrawler(Crawler):
-    """Crawler for OpenDAP resources"""
-
-    LOGGER = logging.getLogger(__name__ + '.OpenDAPCrawler')
-    FOLDERS_SUFFIXES = ('/contents.html')
-    FILES_SUFFIXES = ('.nc', '.nc.gz')
-    EXCLUDE = ('?')
-
-    def __init__(self, root_url):
-        """
-        The _urls attribute contains URLs to the resources which will be returned by the crawler
-        The _to_process attribute contains URLs to pages which need to be searched for resources
-        """
-        self.root_url = root_url
-        self.set_initial_state()
-
-    def set_initial_state(self):
-        self._urls = []
-        self._to_process = [self.root_url.rstrip('/')]
-
-    def __iter__(self):
-        """Make the crawler iterable"""
-        return self
-
-    def __next__(self):
-        """Make the crawler an iterator"""
-        try:
-            # Return all resource URLs from the previously processed folder
-            result = self._urls.pop()
-        except IndexError:
-            # If no more URLs from the previously processed folder are available,
-            # process the next one
-            try:
-                self._explore_page(self._to_process.pop())
-                result = self.__next__()
-            except IndexError:
-                raise StopIteration
-        return result
-
-    def _explore_page(self, folder_url):
-        """Gets all relevant links from a page and feeds the _urls and _to_process attributes"""
-        self.LOGGER.info("Looking for resources in '%s'...", folder_url)
-
-        current_location = re.sub(r'/\w+\.\w+$', '', folder_url)
-        links = self._get_links(self._http_get(folder_url))
-        for link in links:
-            # Select links which do not contain any of the self.EXCLUDE strings
-            if all(map(lambda s, l=link: s not in l, self.EXCLUDE)):
-                if link.endswith(self.FOLDERS_SUFFIXES):
-                    folder_url = f"{current_location}/{link}"
-                    if folder_url not in self._to_process:
-                        self.LOGGER.debug("Adding '%s' to the list of pages to process.", link)
-                        self._to_process.append(folder_url)
-                elif link.endswith(self.FILES_SUFFIXES):
-                    resource_url = f"{current_location}/{link}"
-                    if resource_url not in self._urls:
-                        self.LOGGER.debug("Adding '%s' to the list of resources.", link)
-                        self._urls.append(resource_url)
-
-    @classmethod
-    def _get_links(cls, html):
-        """Returns the list of links contained in an HTML page, passed as a string"""
-
-        parser = LinkExtractor()
-        cls.LOGGER.debug("Parsing HTML data.")
-        parser.feed(html)
-
-        return parser.links
-
-
 class LinkExtractor(HTMLParser):
     """
     HTML parser which extracts links from an HTML page
@@ -141,6 +75,158 @@ class LinkExtractor(HTMLParser):
             for attr in attrs:
                 if attr[0] == 'href':
                     self._links.append(attr[1])
+
+
+class OpenDAPCrawler(Crawler):
+    """Crawler for OpenDAP resources"""
+
+    LOGGER = logging.getLogger(__name__ + '.OpenDAPCrawler')
+    FOLDERS_SUFFIXES = ('/contents.html')
+    FILES_SUFFIXES = ('.nc', '.nc.gz')
+    EXCLUDE = ('?')
+
+    YEAR_PATTERN = r'(\d{4})'
+    MONTH_PATTERN = r'(1[0-2]|0[1-9]|[1-9])'
+    DAY_OF_MONTH_PATTERN = r'(3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9])'
+    DAY_OF_YEAR_PATTERN = r'(36[0-6]|3[0-5]\d|[1-2]\d\d|0[1-9]\d|00[1-9]|[1-9]\d|0[1-9]|[1-9])'
+
+    YEAR_MATCHER = re.compile(f'^.*/{YEAR_PATTERN}/.*$')
+    MONTH_MATCHER = re.compile(f'^.*/{YEAR_PATTERN}/{MONTH_PATTERN}/.*$')
+    DAY_OF_MONTH_MATCHER = re.compile(
+        f'^.*/{YEAR_PATTERN}/{MONTH_PATTERN}/{DAY_OF_MONTH_PATTERN}/.*$')
+    DAY_OF_YEAR_MATCHER = re.compile(f'^.*/{YEAR_PATTERN}/{DAY_OF_YEAR_PATTERN}/.*$')
+
+    TIMESTAMP_MATCHER = re.compile((
+        r'(\d{4})(1[0-2]|0[1-9]|[1-9])(3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9])'
+        r'(2[0-3]|[0-1]\d|\d)([0-5]\d|\d)(6[0-1]|[0-5]\d|\d)'))
+
+    def __init__(self, root_url, time_range=(None, None)):
+        """
+        `root_url` is the URL of the data repository to explore.
+        `time_range` is a tuple of datetime.datetime objects defining the time range of the datasets
+        returned the crawler.
+        """
+        self.root_url = root_url
+        self.time_range = time_range
+        self.set_initial_state()
+
+    def set_initial_state(self):
+        """
+        The `_urls` attribute contains URLs to the resources which will be returned by the crawler.
+        The `_to_process` attribute contains URLs to pages which need to be searched for resources.
+        """
+        self._urls = []
+        self._to_process = [self.root_url.rstrip('/')]
+
+    def __iter__(self):
+        """Make the crawler iterable"""
+        return self
+
+    def __next__(self):
+        """Make the crawler an iterator"""
+        try:
+            # Return all resource URLs from the previously processed folder
+            result = self._urls.pop()
+        except IndexError:
+            # If no more URLs from the previously processed folder are available,
+            # process the next one
+            try:
+                self._explore_page(self._to_process.pop())
+                result = self.__next__()
+            except IndexError:
+                raise StopIteration
+        return result
+
+    def _folder_coverage(self, folder_url):
+        """
+        Find out if the folder has date info in its path. The resolution is one day.
+        For now, it supports the following structures:
+          - .../year/...
+          - .../year/month/...
+          - .../year/month/day/...
+          - .../year/day_of_year/...
+        It will need to be updated to support new structures.
+        """
+        match_year = self.YEAR_MATCHER.search(folder_url)
+        if match_year:
+            match_month = self.MONTH_MATCHER.search(folder_url)
+            if match_month:
+                match_day = self.DAY_OF_MONTH_MATCHER.search(folder_url)
+                if match_day:
+                    folder_coverage_start = datetime(
+                        int(match_year[1]), int(match_month[2]), int(match_day[3]), 0, 0, 0)
+                    folder_coverage_stop = datetime(
+                        int(match_year[1]), int(match_month[2]), int(match_day[3]), 23, 59, 59)
+                else:
+                    last_day_of_month = calendar.monthrange(
+                        int(match_year[1]), int(match_month[2]))[1]
+                    folder_coverage_start = datetime(
+                        int(match_year[1]), int(match_month[2]), 1, 0, 0, 0)
+                    folder_coverage_stop = datetime(
+                        int(match_year[1]), int(match_month[2]), last_day_of_month, 23, 59, 59)
+            else:
+                match_day_of_year = self.DAY_OF_YEAR_MATCHER.search(folder_url)
+                if match_day_of_year:
+                    offset = timedelta(int(match_day_of_year[2]) - 1)
+                    folder_coverage_start = (datetime(int(match_year[1]), 1, 1, 0, 0, 0)
+                                             + offset)
+                    folder_coverage_stop = (datetime(int(match_year[1]), 1, 1, 23, 59, 59)
+                                            + offset)
+                else:
+                    folder_coverage_start = datetime(int(match_year[1]), 1, 1, 0, 0, 0)
+                    folder_coverage_stop = datetime(int(match_year[1]), 12, 31, 23, 59, 59)
+        else:
+            folder_coverage_start = folder_coverage_stop = None
+
+        return (folder_coverage_start, folder_coverage_stop)
+
+    def _dataset_timestamp(self, dataset_name):
+        """Tries to find a timestamp in the dataset's name"""
+        timestamp_match = self.TIMESTAMP_MATCHER.search(dataset_name)
+        if timestamp_match:
+            return datetime.strptime(timestamp_match[0], '%Y%m%d%H%M%S')
+        else:
+            return None
+
+    def _intersects_time_range(self, start_time=None, stop_time=None):
+        """
+        Return True if:
+          - a time coverage was extracted from the folder's path or a timestamp from the dataset's
+            name, and this time coverage intersects with the Crawler's time range
+          - no time range was defined when instantiating the crawler
+          - no time coverage was extracted from the folder's url or dataset's name
+        """
+        return ((not start_time or not self.time_range[1] or start_time <= self.time_range[1]) and
+                (not stop_time or not self.time_range[0] or stop_time >= self.time_range[0]))
+
+    def _explore_page(self, folder_url):
+        """Get all relevant links from a page and feeds the _urls and _to_process attributes"""
+        self.LOGGER.info("Looking for resources in '%s'...", folder_url)
+        current_location = re.sub(r'/\w+\.\w+$', '', folder_url)
+        links = self._get_links(self._http_get(folder_url))
+        for link in links:
+            # Select links which do not contain any of the self.EXCLUDE strings
+            if all(map(lambda s, l=link: s not in l, self.EXCLUDE)):
+                if link.endswith(self.FOLDERS_SUFFIXES):
+                    folder_url = f"{current_location}/{link}"
+                    if folder_url not in self._to_process:
+                        if self._intersects_time_range(*self._folder_coverage(folder_url)):
+                            self.LOGGER.debug("Adding '%s' to the list of pages to process.", link)
+                            self._to_process.append(folder_url)
+                elif link.endswith(self.FILES_SUFFIXES):
+                    resource_url = f"{current_location}/{link}"
+                    if resource_url not in self._urls:
+                        if self._intersects_time_range(*(self._dataset_timestamp(link),) * 2):
+                            self.LOGGER.debug("Adding '%s' to the list of resources.", link)
+                            self._urls.append(resource_url)
+
+    @classmethod
+    def _get_links(cls, html):
+        """Returns the list of links contained in an HTML page, passed as a string"""
+        parser = LinkExtractor()
+        cls.LOGGER.debug("Parsing HTML data.")
+        parser.feed(html)
+        return parser.links
 
 
 class CopernicusOpenSearchAPICrawler(Crawler):

--- a/geospaas_harvesting/harvest.py
+++ b/geospaas_harvesting/harvest.py
@@ -32,7 +32,7 @@ class Configuration(collections.abc.Mapping):
     """Manages harvesting configuration"""
 
     DEFAULT_CONFIGURATION_PATH = os.path.join(os.path.dirname(__file__), 'harvest.yml')
-    TOP_LEVEL_KEYS = set(['harvesters', 'poll_interval'])
+    TOP_LEVEL_KEYS = set(['harvesters', 'poll_interval', 'endless'])
     HARVESTER_CLASS_KEY = 'class'
 
     def __init__(self, config_path=None):
@@ -228,6 +228,8 @@ def main():
                         #Start a new process
                         results[harvester_name] = pool.apply_async(
                             launch_harvest, (harvester_name, harvester_config))
+                if not config.get('endless', False):
+                    break
                 time.sleep(config.get('poll_interval', 600))
             LOGGER.error("All harvester processes encountered errors")
             pool.close()

--- a/geospaas_harvesting/harvest.yml
+++ b/geospaas_harvesting/harvest.yml
@@ -1,4 +1,5 @@
 ---
+endless: False
 poll_interval: 600
 harvesters:
   podaac:

--- a/geospaas_harvesting/harvesters.py
+++ b/geospaas_harvesting/harvesters.py
@@ -104,10 +104,11 @@ class CopernicusSentinelHarvester(Harvester):
     def _create_crawlers(self):
         return [
             crawlers.CopernicusOpenSearchAPICrawler(
-                self.config['url'],
+                url=self.config['url'],
                 search_terms=search,
                 username=self.config.get('username', None),
-                password=os.getenv(self.config.get('password', ''), None))
+                password=os.getenv(self.config.get('password', ''), None),
+                time_range=(self.get_time_range()))
             for search in self.config['search_terms']
         ]
 

--- a/geospaas_harvesting/harvesters.py
+++ b/geospaas_harvesting/harvesters.py
@@ -86,7 +86,10 @@ class Harvester():
 class PODAACHarvester(Harvester):
     """Harvester class for PODAAC data (NASA)"""
     def _create_crawlers(self):
-        return [crawlers.OpenDAPCrawler(url) for url in self.config['urls']]
+        return [
+            crawlers.OpenDAPCrawler(url, time_range=(self.get_time_range()))
+            for url in self.config['urls']
+        ]
 
     def _create_ingester(self):
         parameters = {}

--- a/tests/data/opendap/folder/2019/02/14/contents.html
+++ b/tests/data/opendap/folder/2019/02/14/contents.html
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns:bes="http://xml.opendap.org/ns/bes/1.0#">
+
+<head>
+    <link rel="stylesheet" href="/opendap/docs/css/contents.css" type="text/css" />
+    <title>OPeNDAP Hyrax: Contents of /folder/</title>
+</head>
+
+<body>
+    <img alt="OPeNDAP Logo" src="/opendap/docs/images/logo.png" />
+    <h1>Contents of
+        /folder/</h1>
+    <hr size="1" noshade="noshade" />
+    <pre>
+         <table border="0" width="100%" itemscope="" itemtype="http://schema.org/DataCatalog">
+            <caption style="display:none">
+               <a itemprop="url" href="#">
+                  <span itemprop="name">/folder/</span>
+               </a>
+            </caption>
+            <tr>
+               <th align="left">Name</th>
+               <th align="center">Last Modified</th>
+               <th align="center">Size</th>
+               <th align="center">DAP Response Links</th>
+               <th align="center">Dataset Viewers</th>
+            </tr>
+            <tr>
+               <td/>
+            </tr>
+            <tr itemprop="dataset" itemscope="" itemtype="http://schema.org/Dataset">
+               <td align="left">
+                  <b>
+                     <a href="20190214000000_dataset.nc.html">
+                        <span itemprop="name">20190214000000_dataset.nc</span>
+                     </a>
+                  </b>
+               </td>
+               <td align="center" nowrap="nowrap">
+                  <time itemprop="dateModified" datetime="2020-01-01T21:28:38GMT">2020-01-01T21:28:38GMT</time>
+               </td>
+               <td align="right">83468497</td>
+               <td align="center">
+                  <table>
+                     <tr>
+                        <td itemprop="distribution" itemscope="" itemtype="http://schema.org/DataDownload">
+                           <meta itemprop="name" content="20190214000000_dataset.nc"/>
+                           <meta itemprop="contentSize" content="83468497"/>
+                           <a itemprop="contentUrl"
+                              href="20190214000000_dataset.nc">file</a>&nbsp;</td>
+                     </tr>
+                     <tr>
+                        <td itemprop="distribution" itemscope="" itemtype="http://schema.org/DataDownload">
+                           <meta itemprop="name" content="20190214120000_dataset.nc" />
+                           <meta itemprop="contentSize" content="83468497" />
+                           <a itemprop="contentUrl" href="20190214120000_dataset.nc">file</a>&nbsp;</td>
+                     </tr>
+                  </table>
+               </td>
+               <td align="center"><!--viewersService: /opendap/viewers--><a href="/opendap/viewers/viewers?dapService=/opendap/hyrax&amp;datasetID=/folder/20190214000000_dataset.nc">viewers</a>
+               </td>
+            </tr>
+         </table>
+      </pre>
+</body>
+
+</html>

--- a/tests/data/opendap/folder/2019/02/contents.html
+++ b/tests/data/opendap/folder/2019/02/contents.html
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns:bes="http://xml.opendap.org/ns/bes/1.0#">
+
+<head>
+    <link rel="stylesheet" href="/opendap/docs/css/contents.css" type="text/css" />
+    <title>OPeNDAP Hyrax: Contents of /folder/</title>
+</head>
+
+<body>
+    <img alt="OPeNDAP Logo" src="/opendap/docs/images/logo.png" />
+    <h1>Contents of
+        /folder/</h1>
+    <hr size="1" noshade="noshade" />
+    <pre>
+         <table border="0" width="100%" itemscope="" itemtype="http://schema.org/DataCatalog">
+            <caption style="display:none">
+               <a itemprop="url" href="#">
+                  <span itemprop="name">/folder/</span>
+               </a>
+            </caption>
+            <tr>
+               <th align="left">Name</th>
+               <th align="center">Last Modified</th>
+               <th align="center">Size</th>
+               <th align="center">DAP Response Links</th>
+               <th align="center">Dataset Viewers</th>
+            </tr>
+            <tr>
+               <td/>
+            </tr>
+            <tr>
+               <td align="left">
+                  <a href="14/contents.html">2019/</a>
+               </td>
+            </tr>
+         </table>
+      </pre>
+</body>
+
+</html>

--- a/tests/data/opendap/folder/2019/046/contents.html
+++ b/tests/data/opendap/folder/2019/046/contents.html
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns:bes="http://xml.opendap.org/ns/bes/1.0#">
+
+<head>
+    <link rel="stylesheet" href="/opendap/docs/css/contents.css" type="text/css" />
+    <title>OPeNDAP Hyrax: Contents of /folder/</title>
+</head>
+
+<body>
+    <img alt="OPeNDAP Logo" src="/opendap/docs/images/logo.png" />
+    <h1>Contents of
+        /folder/</h1>
+    <hr size="1" noshade="noshade" />
+    <pre>
+         <table border="0" width="100%" itemscope="" itemtype="http://schema.org/DataCatalog">
+            <caption style="display:none">
+               <a itemprop="url" href="#">
+                  <span itemprop="name">/folder/</span>
+               </a>
+            </caption>
+            <tr>
+               <th align="left">Name</th>
+               <th align="center">Last Modified</th>
+               <th align="center">Size</th>
+               <th align="center">DAP Response Links</th>
+               <th align="center">Dataset Viewers</th>
+            </tr>
+            <tr>
+               <td/>
+            </tr>
+            <tr itemprop="dataset" itemscope="" itemtype="http://schema.org/Dataset">
+               <td align="left">
+                  <b>
+                     <a href="20190215000000_dataset.nc.html">
+                        <span itemprop="name">20190215000000_dataset.nc</span>
+                     </a>
+                  </b>
+               </td>
+               <td align="center" nowrap="nowrap">
+                  <time itemprop="dateModified" datetime="2020-01-01T21:28:38GMT">2020-01-01T21:28:38GMT</time>
+               </td>
+               <td align="right">83468497</td>
+               <td align="center">
+                  <table>
+                     <tr>
+                        <td itemprop="distribution" itemscope="" itemtype="http://schema.org/DataDownload">
+                           <meta itemprop="name" content="20190215000000_dataset.nc"/>
+                           <meta itemprop="contentSize" content="83468497"/>
+                           <a itemprop="contentUrl"
+                              href="20190215000000_dataset.nc">file</a>&nbsp;</td>
+                     </tr>
+                     <tr>
+                        <td itemprop="distribution" itemscope="" itemtype="http://schema.org/DataDownload">
+                           <meta itemprop="name" content="20190215120000_dataset.nc" />
+                           <meta itemprop="contentSize" content="83468497" />
+                           <a itemprop="contentUrl" href="20190215120000_dataset.nc">file</a>&nbsp;</td>
+                     </tr>
+                  </table>
+               </td>
+               <td align="center"><!--viewersService: /opendap/viewers--><a href="/opendap/viewers/viewers?dapService=/opendap/hyrax&amp;datasetID=/folder/20190215000000_dataset.nc">viewers</a>
+               </td>
+            </tr>
+         </table>
+      </pre>
+</body>
+
+</html>

--- a/tests/data/opendap/folder/2019/contents.html
+++ b/tests/data/opendap/folder/2019/contents.html
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns:bes="http://xml.opendap.org/ns/bes/1.0#">
+
+<head>
+    <link rel="stylesheet" href="/opendap/docs/css/contents.css" type="text/css" />
+    <title>OPeNDAP Hyrax: Contents of /folder/</title>
+</head>
+
+<body>
+    <img alt="OPeNDAP Logo" src="/opendap/docs/images/logo.png" />
+    <h1>Contents of
+        /folder/</h1>
+    <hr size="1" noshade="noshade" />
+    <pre>
+         <table border="0" width="100%" itemscope="" itemtype="http://schema.org/DataCatalog">
+            <caption style="display:none">
+               <a itemprop="url" href="#">
+                  <span itemprop="name">/folder/</span>
+               </a>
+            </caption>
+            <tr>
+               <th align="left">Name</th>
+               <th align="center">Last Modified</th>
+               <th align="center">Size</th>
+               <th align="center">DAP Response Links</th>
+               <th align="center">Dataset Viewers</th>
+            </tr>
+            <tr>
+               <td/>
+            </tr>
+            <tr>
+               <td align="left">
+                  <a href="02/contents.html">2019/</a>
+               </td>
+            </tr>
+            <tr>
+               <td align="left">
+                  <a href="046/contents.html">2019/</a>
+               </td>
+            </tr>
+         </table>
+      </pre>
+</body>
+
+</html>

--- a/tests/data/opendap/folder/contents.html
+++ b/tests/data/opendap/folder/contents.html
@@ -97,6 +97,11 @@
                <td align="center"><!--viewersService: /opendap/viewers--><a href="/opendap/viewers/viewers?dapService=/opendap/hyrax&amp;datasetID=/folder/dataset.nc">viewers</a>
                </td>
             </tr>
+            <tr>
+               <td align="left">
+                  <a href="2019/contents.html">2019/</a>
+               </td>
+            </tr>
          </table>
       </pre>
 </body>

--- a/tests/test_crawlers.py
+++ b/tests/test_crawlers.py
@@ -5,6 +5,7 @@ import logging
 import os
 import unittest
 import unittest.mock as mock
+from datetime import datetime
 
 import requests
 
@@ -25,31 +26,43 @@ class OpenDAPCrawlerTestCase(unittest.TestCase):
 
     TEST_DATA = {
         'root': {
-            'url': "https://test-opendap.com",
+            'urls': ["https://test-opendap.com"],
             'file_path': "data/opendap/root.html"},
         'root_duplicates': {
-            'url': "https://test2-opendap.com",
+            'urls': ["https://test2-opendap.com"],
             'file_path': "data/opendap/root_duplicates.html"},
-        'root_dataset': {
-            'url': 'https://test-opendap.com/dataset.nc',
-            'file_path': None},
-        'root_dataset_2': {
-            'url': 'https://test2-opendap.com/dataset.nc',
+        'dataset': {
+            'urls': [
+                'https://test-opendap.com/dataset.nc',
+                'https://test2-opendap.com/dataset.nc',
+                'https://test-opendap.com/folder/dataset.nc',
+                'https://test-opendap.com/folder/2019/02/14/20190214000000_dataset.nc',
+                'https://test-opendap.com/folder/2019/046/20190215000000_dataset.nc'
+            ],
             'file_path': None},
         'folder': {
-            'url': 'https://test-opendap.com/folder/contents.html',
-            'file_path': 'data/opendap/folder.html'},
-        'folder_2': {
-            'url': 'https://test2-opendap.com/folder/contents.html',
-            'file_path': 'data/opendap/folder.html'},
-        'folder_dataset': {
-            'url': 'https://test-opendap.com/folder/dataset.nc',
-            'file_path': None},
+            'urls': [
+                'https://test-opendap.com/folder/contents.html',
+                'https://test2-opendap.com/folder/contents.html'
+            ],
+            'file_path': 'data/opendap/folder/contents.html'},
+        'folder_year': {
+            'urls': ['https://test-opendap.com/folder/2019/contents.html'],
+            'file_path': 'data/opendap/folder/2019/contents.html'},
+        'folder_month': {
+            'urls': ['https://test-opendap.com/folder/2019/02/contents.html'],
+            'file_path': 'data/opendap/folder/2019/02/contents.html'},
+        'folder_day_of_month': {
+            'urls': ['https://test-opendap.com/folder/2019/02/14/contents.html'],
+            'file_path': 'data/opendap/folder/2019/02/14/contents.html'},
+        'folder_day_of_year': {
+            'urls': ['https://test-opendap.com/folder/2019/046/contents.html'],
+            'file_path': 'data/opendap/folder/2019/046/contents.html'},
         'empty': {
-            'url': 'http://empty.com',
+            'urls': ['http://empty.com'],
             'file_path': 'data/empty.html'},
         'inexistent': {
-            'url': 'http://random.url',
+            'urls': ['http://random.url'],
             'file_path': None}
     }
 
@@ -57,8 +70,9 @@ class OpenDAPCrawlerTestCase(unittest.TestCase):
         """Side effect function used to mock calls to requests.get().text"""
         data_file_relative_path = None
         for test_data in self.TEST_DATA.values():
-            if url == test_data['url']:
+            if url in test_data['urls']:
                 data_file_relative_path = test_data['file_path']
+                break
 
         response = requests.Response()
 
@@ -92,15 +106,17 @@ class OpenDAPCrawlerTestCase(unittest.TestCase):
 
     def test_instantiation(self):
         """Test the correct instantiation of an Opendap crawler"""
-        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root']['url'])
+        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root']['urls'][0])
         self.assertIsInstance(crawler, crawlers.Crawler)
+        self.assertEqual(crawler.root_url, self.TEST_DATA['root']['urls'][0])
+        self.assertEqual(crawler.time_range, (None, None))
         self.assertListEqual(crawler._urls, [])
-        self.assertListEqual(crawler._to_process, [self.TEST_DATA['root']['url']])
+        self.assertListEqual(crawler._to_process, [self.TEST_DATA['root']['urls'][0]])
 
     def test_set_initial_state(self):
         """Tests that the set_initial_state() method sets the correct values"""
         #Create a crawler and start iterating to set a non-initial state
-        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root']['url'])
+        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root']['urls'][0])
         with self.assertLogs(crawler.LOGGER):
             next(iter(crawler))
 
@@ -114,14 +130,14 @@ class OpenDAPCrawlerTestCase(unittest.TestCase):
         html = data_file.read()
         data_file.close()
 
-        html_from_method = crawlers.OpenDAPCrawler._http_get(self.TEST_DATA['root']['url'])
+        html_from_method = crawlers.OpenDAPCrawler._http_get(self.TEST_DATA['root']['urls'][0])
 
         self.assertEqual(html, html_from_method)
 
     @mock.patch('logging.Logger.error')
     def test_get_html_logs_error_on_http_status(self, mock_error_logger):
         """Test that an exception is raised in case of HTTP error code"""
-        _ = crawlers.OpenDAPCrawler._http_get(self.TEST_DATA['inexistent']['url'])
+        _ = crawlers.OpenDAPCrawler._http_get(self.TEST_DATA['inexistent']['urls'][0])
         mock_error_logger.assert_called_once()
 
     def test_get_right_number_of_links(self):
@@ -149,35 +165,230 @@ class OpenDAPCrawlerTestCase(unittest.TestCase):
         Explore root page and make sure the _url and _to_process attributes of the crawler have the
         right values
         """
-        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root']['url'])
+        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root']['urls'][0])
         with self.assertLogs(crawler.LOGGER):
             crawler._explore_page(crawler._to_process.pop())
-        self.assertListEqual(crawler._urls, [self.TEST_DATA['root_dataset']['url']])
-        self.assertListEqual(crawler._to_process, [self.TEST_DATA['folder']['url']])
+        self.assertListEqual(crawler._urls, [self.TEST_DATA['dataset']['urls'][0]])
+        self.assertListEqual(crawler._to_process, [self.TEST_DATA['folder']['urls'][0]])
 
     def test_explore_page_with_duplicates(self):
         """If the same URL is present twice in the page, it should only be processed once"""
-        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root_duplicates']['url'])
+        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root_duplicates']['urls'][0])
         with self.assertLogs(crawler.LOGGER):
             crawler._explore_page(crawler._to_process.pop())
-        self.assertListEqual(crawler._urls, [self.TEST_DATA['root_dataset_2']['url']])
-        self.assertListEqual(crawler._to_process, [self.TEST_DATA['folder_2']['url']])
+        self.assertListEqual(crawler._urls, [self.TEST_DATA['dataset']['urls'][1]])
+        self.assertListEqual(crawler._to_process, [self.TEST_DATA['folder']['urls'][1]])
+
+    def test_explore_page_with_time_restriction_discriminated_by_timestamp(self):
+        """
+        Explore a page and make sure the _url and _to_process attributes of the crawler have the
+        right values according to a time restriction
+        """
+        crawler = crawlers.OpenDAPCrawler(
+            self.TEST_DATA['folder_day_of_year']['urls'][0],
+            time_range=(datetime(2019, 2, 15, 11, 0, 0), datetime(2019, 2, 15, 13, 0, 0)))
+        with self.assertLogs(crawler.LOGGER):
+            crawler._explore_page(crawler._to_process.pop())
+        self.assertListEqual(crawler._urls,
+                             ['https://test-opendap.com/folder/2019/046/20190215120000_dataset.nc'])
+        self.assertListEqual(crawler._to_process, [])
+
+    def test_explore_page_with_time_restriction_discriminated_by_folder_coverage(self):
+        """
+        Explore a page and make sure the _url and _to_process attributes of the crawler have the
+        right values according to a time restriction
+        """
+        crawler = crawlers.OpenDAPCrawler(
+            self.TEST_DATA['folder_day_of_year']['urls'][0],
+            time_range=(datetime(2019, 2, 11, 11, 0, 0), datetime(2019, 2, 11, 13, 0, 0)))
+        with self.assertLogs(crawler.LOGGER):
+            crawler._explore_page(crawler._to_process.pop())
+        self.assertListEqual(crawler._urls, [])
+        self.assertListEqual(crawler._to_process, [])
 
     def test_iterating(self):
         """Test the call to the __iter__ method"""
-        crawler = crawlers.OpenDAPCrawler(self.TEST_DATA['root']['url'])
+        crawler = crawlers.OpenDAPCrawler(
+            self.TEST_DATA['root']['urls'][0],
+            time_range=(datetime(2019, 2, 14, 0, 0, 0), datetime(2019, 2, 14, 9, 0, 0)))
         crawler_iterator = iter(crawler)
 
         # Test the values returned by the iterator
         with self.assertLogs(crawler.LOGGER):
-            self.assertEqual(next(crawler_iterator), self.TEST_DATA['root_dataset']['url'])
-            self.assertEqual(next(crawler_iterator), self.TEST_DATA['folder_dataset']['url'])
+            self.assertEqual(next(crawler_iterator), self.TEST_DATA['dataset']['urls'][0])
+            self.assertEqual(next(crawler_iterator), self.TEST_DATA['dataset']['urls'][2])
+            self.assertEqual(next(crawler_iterator), self.TEST_DATA['dataset']['urls'][3])
 
         # Test that a StopIteration is returned at the end. The nested context managers are
         # necessary because the StopIteration exception is raised inside an 'except KeyError:' block
         with self.assertRaises(StopIteration):
             with self.assertRaises(KeyError):
                 next(crawler)
+
+    def test_get_year_folder_coverage(self):
+        """Get the correct time range from a year folder"""
+        crawler = crawlers.OpenDAPCrawler('')
+        self.assertEqual(
+            crawler._folder_coverage('https://test-opendap.com/folder/2019/contents.html'),
+            (datetime(2019, 1, 1, 0, 0, 0), datetime(2019, 12, 31, 23, 59, 59))
+        )
+
+    def test_get_month_folder_coverage(self):
+        """Get the correct time range from a month folder"""
+        crawler = crawlers.OpenDAPCrawler('')
+        self.assertEqual(
+            crawler._folder_coverage('https://test-opendap.com/folder/2019/02/contents.html'),
+            (datetime(2019, 2, 1, 0, 0, 0), datetime(2019, 2, 28, 23, 59, 59))
+        )
+
+    def test_get_day_of_month_folder_coverage(self):
+        """Get the correct time range from a day of month folder"""
+        crawler = crawlers.OpenDAPCrawler('')
+        self.assertEqual(
+            crawler._folder_coverage('https://test-opendap.com/folder/2019/02/14/contents.html'),
+            (datetime(2019, 2, 14, 0, 0, 0), datetime(2019, 2, 14, 23, 59, 59))
+        )
+
+    def test_get_day_of_year_folder_coverage(self):
+        """Get the correct time range from a day of year folder"""
+        crawler = crawlers.OpenDAPCrawler('')
+        self.assertEqual(
+            crawler._folder_coverage('https://test-opendap.com/folder/2019/046/contents.html'),
+            (datetime(2019, 2, 15, 0, 0, 0), datetime(2019, 2, 15, 23, 59, 59))
+        )
+
+    def test_none_when_no_folder_coverage(self):
+        """
+        The `_folder_coverage` method should return `None` if no time range is inferred from the
+        folder's path
+        """
+        crawler = crawlers.OpenDAPCrawler('')
+        self.assertEqual(
+            crawler._folder_coverage('https://test-opendap.com/folder/contents.html'), (None, None))
+        self.assertEqual(
+            crawler._folder_coverage('https://test-opendap.com/folder/046/contents.html'),
+            (None, None)
+        )
+        self.assertEqual(
+            crawler._folder_coverage('https://test-opendap.com/folder/02/contents.html'),
+            (None, None)
+        )
+
+    def test_get_dataset_timestamp(self):
+        """Get the correct date from a dataset prefixed by a timestamp"""
+        crawler = crawlers.OpenDAPCrawler('')
+        self.assertEqual(
+            crawler._dataset_timestamp('20190214090812_dataset_name.nc'),
+            datetime(2019, 2, 14, 9, 8, 12),
+        )
+
+    def test_none_when_no_dataset_timestamp(self):
+        """
+        The `_dataset_timestamp` method should return `None` if no timestamp is found in the
+        dataset's name
+        """
+        crawler = crawlers.OpenDAPCrawler('')
+        self.assertEqual(crawler._dataset_timestamp('dataset_name.nc'), None)
+
+
+    def test_intersects_time_range_finite_limits(self):
+        """
+        Test the behavior of the `_intersects_time_range` method with a finite time range limitation
+        `time_range[0]` and `time_range[1]` are the limits defined in the crawler
+        `start_time` and `stop_time` are the limits of the time range which is tested against the
+        crawler's condition
+        """
+        crawler = crawlers.OpenDAPCrawler(
+            '', time_range=(datetime(2019, 2, 14), datetime(2019, 2, 20)))
+
+        # start_time < time_range[0] < stop_time < time_range[1]
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 10), datetime(2019, 2, 17)))
+        # start_time < time_range[0] == stop_time < time_range[1]
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 10), datetime(2019, 2, 14)))
+        # time_range[0] < start_time < time_range[1] < stop_time
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 17), datetime(2019, 2, 25)))
+        # time_range[0] < start_time == time_range[1] < stop_time
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 20), datetime(2019, 2, 25)))
+        # time_range[0] < start_time < stop_time < time_range[1]
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 15), datetime(2019, 2, 19)))
+        # start_time < time_range[0] < time_range[1] < stop_time
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 13), datetime(2019, 2, 25)))
+        # start_time < stop_time < time_range[0] < time_range[1]
+        self.assertFalse(crawler._intersects_time_range(
+            datetime(2019, 2, 10), datetime(2019, 2, 13)))
+        # time_range[0] < time_range[1] < start_time < stop_time
+        self.assertFalse(crawler._intersects_time_range(
+            datetime(2019, 2, 25), datetime(2019, 2, 26)))
+        # no start_time < time_range[0] < time_range[1] < stop_time
+        self.assertTrue(crawler._intersects_time_range(None, datetime(2019, 2, 27)))
+        # no start_time < time_range[0] < stop_time < time_range[1]
+        self.assertTrue(crawler._intersects_time_range(None, datetime(2019, 2, 17)))
+        # no start_time < stop_time < time_range[0] < time_range[1]
+        self.assertFalse(crawler._intersects_time_range(None, datetime(2019, 2, 10)))
+        # start_time < time_range[0] < time_range[1] < no stop time
+        self.assertTrue(crawler._intersects_time_range(datetime(2019, 2, 10), None))
+        # time_range[0] < start_time < time_range[1] < no stop time
+        self.assertTrue(crawler._intersects_time_range(datetime(2019, 2, 18), None))
+        # time_range[0] < time_range[1] < start_time < no stop time
+        self.assertFalse(crawler._intersects_time_range(datetime(2019, 2, 21), None))
+
+    def test_intersects_time_range_no_lower_limit(self):
+        """
+        Test the behavior of the `_intersects_time_range` method without a lower limit for the
+        crawler's time range.
+        `time_range[1]` is the upper limit defined in the crawler
+        `start_time` and `stop_time` are the limits of the time range which is tested against the
+        crawler's condition
+        """
+        crawler = crawlers.OpenDAPCrawler('', time_range=(None, datetime(2019, 2, 20)))
+
+        # no lower limit < time_range[1] < start_time < stop_time
+        self.assertFalse(crawler._intersects_time_range(
+            datetime(2019, 2, 25), datetime(2019, 2, 26)))
+        # no lower limit < start_time < time_range[1] < stop_time
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 18), datetime(2019, 2, 26)))
+        # no lower limit < start_time < stop_time < time_range[1]
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 18), datetime(2019, 2, 19)))
+        # no lower limit and no start time
+        self.assertTrue(crawler._intersects_time_range(None, datetime(2019, 2, 21)))
+        # no lower limit and no stop_time, with intersection
+        self.assertTrue(crawler._intersects_time_range(datetime(2019, 2, 19), None))
+        # no lower limit and no stop_time, without intersection
+        self.assertFalse(crawler._intersects_time_range(datetime(2019, 2, 21), None))
+
+    def test_intersects_time_range_no_upper_limit(self):
+        """
+        Test the behavior of the `_intersects_time_range` method without an upper limit for the
+        crawler's time range.
+        `time_range[0]` is the upper limit defined in the crawler
+        `start_time` and `stop_time` are the limits of the time range which is tested against the
+        crawler's condition
+        """
+        crawler = crawlers.OpenDAPCrawler('', time_range=(datetime(2019, 2, 20), None))
+
+        # start_time < stop_time < time_range[0] < no upper limit
+        self.assertFalse(crawler._intersects_time_range(
+            datetime(2019, 2, 10), datetime(2019, 2, 15)))
+        # start_time < time_range[0] < stop_time < no upper limit
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 18), datetime(2019, 2, 26)))
+        # time_range[0] < start_time < stop_time < no upper limit
+        self.assertTrue(crawler._intersects_time_range(
+            datetime(2019, 2, 21), datetime(2019, 2, 25)))
+        # no upper limit and no stop_time
+        self.assertTrue(crawler._intersects_time_range(datetime(2019, 2, 21), None))
+        # no upper limit and no start_time, with intersection
+        self.assertTrue(crawler._intersects_time_range(None, datetime(2019, 2, 21)))
+        # no upper limit and no start_time, without intersection
+        self.assertFalse(crawler._intersects_time_range(None, datetime(2019, 2, 19)))
 
 
 class CopernicusOpenSearchAPICrawlerTestCase(unittest.TestCase):

--- a/tests/test_harvesters.py
+++ b/tests/test_harvesters.py
@@ -11,8 +11,6 @@ import geospaas_harvesting.harvesters as harvesters
 
 from .stubs import StubHarvester, StubIngester
 
-TOP_PACKAGE = 'geospaas_harvesting'
-
 
 class HarvesterTestCase(unittest.TestCase):
     """Test the base harvester"""


### PR DESCRIPTION
Add a `time_range` parameter. When applicable, the crawlers will only return datasets within this time range.
Also add a configuration parameter to toggle endless harvesting mode.