### PR TITLE
Use a string instead of a GEOSGeometry in DDXIngester tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 env:
   global:
     - BASE_IMAGE_NAME="${DOCKER_ORG}/geospaas:v1.0.1"
-    - METANORM_VERSION='1.3.0'
+    - METANORM_VERSION='2.0.0'
 
 jobs:
   include:

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -432,14 +432,13 @@ class DDXIngesterTestCase(django.test.TestCase):
         self.assertEqual(normalized_parameters['platform']['Series_Entity'],
                          'Joint Polar Satellite System (JPSS)')
 
-        self.assertEqual(normalized_parameters['location_geometry'], GEOSGeometry(
-            'POLYGON((' +
-            '-175.084000 -15.3505001,' +
-            '-142.755005 -15.3505001,' +
-            '-142.755005 9.47472000,' +
-            '-175.084000 9.47472000,' +
-            '-175.084000 -15.3505001))',
-            srid=4326
+        self.assertEqual(normalized_parameters['location_geometry'], (
+            'POLYGON(('
+            '-175.084000 -15.3505001,'
+            '-142.755005 -15.3505001,'
+            '-142.755005 9.47472000,'
+            '-175.084000 9.47472000,'
+            '-175.084000 -15.3505001))'
         ))
 
         self.assertEqual(normalized_parameters['provider']['Short_Name'],


### PR DESCRIPTION
Resolves #30 

We must keep in mind that tests in Travis CI are run with a tagged version of `metanorm`.

When modifications which affect `geospaas_harvesting` are made on the master of `metanorm`, the tests must be run locally to be sure that it all works well together.