### PR TITLE
#27 put url into fields of raw_attribute for ddx ingester

### DIFF
--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -374,7 +374,6 @@ class DDXIngester(MetanormIngester):
 
     def _get_normalized_attributes(self, url, *args, **kwargs):
         """Get normalized metadata from the DDX info of the dataset located at the provided URL"""
-        original_url = url
         prepared_url = self.prepare_url(url)
         # Get the metadata from the dataset as an XML tree
         stream = io.BytesIO(requests.get(prepared_url, stream=True).content)

--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -445,7 +445,6 @@ class URLNameIngester(MetanormIngester):
         # TODO: add FTP_SERVICE_NAME and FTP_SERVICE in django-geo-spaas
         normalized_attributes['geospaas_service_name'] = 'ftp'
         normalized_attributes['geospaas_service'] = 'ftp'
-        #Temporary solution
         return normalized_attributes
 
 

--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -380,7 +380,7 @@ class DDXIngester(MetanormIngester):
         # Get all the global attributes of the Dataset into a dictionary
         extracted_attributes = self._extract_attributes(
             ET.parse(stream).getroot())
-        self.add_url(original_url, extracted_attributes)
+        self.add_url(url, extracted_attributes)
         # Get the parameters needed to create a geospaas catalog dataset from the global attributes
         normalized_attributes = self._metadata_handler.get_parameters(extracted_attributes)
         normalized_attributes['geospaas_service'] = OPENDAP_SERVICE

--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -446,7 +446,6 @@ class URLNameIngester(MetanormIngester):
         normalized_attributes['geospaas_service_name'] = 'ftp'
         normalized_attributes['geospaas_service'] = 'ftp'
         #Temporary solution
-        #normalized_attributes['entry_id'] = urlparse(url).path.split('/')[-1]#'entry_id'is file name
         return normalized_attributes
 
 

--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -279,6 +279,7 @@ class MetanormIngester(Ingester):
 
     DATASET_PARAMETER_NAMES = [
         'entry_title',
+        'entry_id',
         'summary',
         'time_coverage_start',
         'time_coverage_end',
@@ -373,14 +374,14 @@ class DDXIngester(MetanormIngester):
 
     def _get_normalized_attributes(self, url, *args, **kwargs):
         """Get normalized metadata from the DDX info of the dataset located at the provided URL"""
-
+        original_url = url
         prepared_url = self.prepare_url(url)
         # Get the metadata from the dataset as an XML tree
         stream = io.BytesIO(requests.get(prepared_url, stream=True).content)
         # Get all the global attributes of the Dataset into a dictionary
         extracted_attributes = self._extract_attributes(
             ET.parse(stream).getroot())
-
+        self.add_url(original_url, extracted_attributes)
         # Get the parameters needed to create a geospaas catalog dataset from the global attributes
         normalized_attributes = self._metadata_handler.get_parameters(extracted_attributes)
         normalized_attributes['geospaas_service'] = OPENDAP_SERVICE
@@ -446,7 +447,7 @@ class URLNameIngester(MetanormIngester):
         normalized_attributes['geospaas_service_name'] = 'ftp'
         normalized_attributes['geospaas_service'] = 'ftp'
         #Temporary solution
-        normalized_attributes['entry_id'] = urlparse(url).path.split('/')[-1]#'entry_id'is file name
+        #normalized_attributes['entry_id'] = urlparse(url).path.split('/')[-1]#'entry_id'is file name
         return normalized_attributes
 
 

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -409,7 +409,7 @@ class DDXIngesterTestCase(django.test.TestCase):
         """Test that the correct attributes are extracted from a DDX file"""
         ingester = ingesters.DDXIngester()
         normalized_parameters = ingester._get_normalized_attributes(
-            "https://opendap.jpl.nasa.gov/opendap/Afull_dataset.nc")
+            "https://opendap.jpl.nasa.gov/opendap/full_dataset.nc")
 
         self.assertEqual(normalized_parameters['entry_title'],
                          'VIIRS L2P Sea Surface Skin Temperature')
@@ -464,7 +464,7 @@ class DDXIngesterTestCase(django.test.TestCase):
         self.assertEqual(normalized_parameters['gcmd_location']
                          ['Location_Category'], 'VERTICAL LOCATION')
         self.assertEqual(normalized_parameters['gcmd_location']['Location_Type'], 'SEA SURFACE')
-        self.assertEqual(normalized_parameters['entry_id'], 'Afull_dataset')
+        self.assertEqual(normalized_parameters['entry_id'], 'full_dataset')
 
     def test_ingest_dataset_twice_different_urls(self):
         """The same dataset must not be ingested twice in the case of second time execution of
@@ -472,11 +472,11 @@ class DDXIngesterTestCase(django.test.TestCase):
         initial_datasets_count = Dataset.objects.count()
         ingester = ingesters.DDXIngester()
         with self.assertLogs(ingester.LOGGER):
-            ingester.ingest(["https://opendap.jpl.nasa.gov/opendap/Afull_dataset.nc"])
+            ingester.ingest(["https://opendap.jpl.nasa.gov/opendap/full_dataset.nc"])
         self.assertEqual(Dataset.objects.count(), initial_datasets_count + 1)
 
         with self.assertLogs(ingester.LOGGER, level=logging.INFO) as logger_cm:
-            ingester.ingest(["https://opendap.jpl.nasa.gov/opendap/Afull_dataset.nc"])
+            ingester.ingest(["https://opendap.jpl.nasa.gov/opendap/full_dataset.nc"])
 
         self.assertTrue(logger_cm.records[0].msg.endswith('already present in the database'))
         self.assertEqual(Dataset.objects.count(), initial_datasets_count + 1)

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -290,15 +290,13 @@ class MetanormIngesterTestCase(django.test.TestCase):
         self.assertEqual(inserted_dataset.geographic_location.geometry,
                          GEOSGeometry(('POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))'), srid=4326))
 
+
 class DDXIngesterTestCase(django.test.TestCase):
     """Test the DDXIngester"""
 
     TEST_DATA = {
         'full_ddx': {
-            'url': "https://test-opendap.com/full_dataset.nc.ddx",
-            'file_path': "data/opendap/full_ddx.xml"},
-        'full_ddx_2': {
-            'url': "https://test-opendap2.com/full_dataset.nc.ddx",
+            'url': "https://opendap.jpl.nasa.gov/opendap/Afull_dataset.nc.ddx",
             'file_path': "data/opendap/full_ddx.xml"},
         'short_ddx': {
             'url': "https://test-opendap.com/short_dataset.nc.ddx",
@@ -360,6 +358,18 @@ class DDXIngesterTestCase(django.test.TestCase):
 
         self.assertEqual(ingester._get_xml_namespace(root), 'http://xml.opendap.org/ns/DAP/3.2#')
 
+    @mock.patch('xml.etree.ElementTree.parse')
+    @mock.patch('geospaas_harvesting.ingesters.DDXIngester._extract_attributes')
+    @mock.patch('metanorm.handlers.MetadataHandler.get_parameters')
+    def test_exsistence_url_in_raw_attributes(self, mock_get_parameters, mock_extatt, mock_etree):
+        """the 'url' field in the "get_parameters" call of function must be present as an
+        input argument. This is a strict need of metanorm for creating the 'entry_id' based
+        on this 'url' field for this ingester."""
+        mock_extatt.return_value = {}
+        ingester = ingesters.DDXIngester()
+        ingester._get_normalized_attributes('test_url')
+        self.assertIn(({'url': 'test_url'},), mock_get_parameters.call_args)
+
     def test_logging_if_no_namespace(self):
         """A warning must be logged if no namespace has been found, and an empty string returned"""
         test_file_path = os.path.join(
@@ -399,7 +409,7 @@ class DDXIngesterTestCase(django.test.TestCase):
         """Test that the correct attributes are extracted from a DDX file"""
         ingester = ingesters.DDXIngester()
         normalized_parameters = ingester._get_normalized_attributes(
-            self.TEST_DATA['full_ddx']['url'])
+            "https://opendap.jpl.nasa.gov/opendap/Afull_dataset.nc")
 
         self.assertEqual(normalized_parameters['entry_title'],
                          'VIIRS L2P Sea Surface Skin Temperature')
@@ -454,20 +464,21 @@ class DDXIngesterTestCase(django.test.TestCase):
         self.assertEqual(normalized_parameters['gcmd_location']
                          ['Location_Category'], 'VERTICAL LOCATION')
         self.assertEqual(normalized_parameters['gcmd_location']['Location_Type'], 'SEA SURFACE')
+        self.assertEqual(normalized_parameters['entry_id'], 'Afull_dataset')
 
     def test_ingest_dataset_twice_different_urls(self):
-        """The same dataset must not be ingested twice even if it is present at different URLs"""
+        """The same dataset must not be ingested twice in the case of second time execution of
+        'ingest' command with the same url. """
         initial_datasets_count = Dataset.objects.count()
-
         ingester = ingesters.DDXIngester()
         with self.assertLogs(ingester.LOGGER):
-            ingester.ingest([self.TEST_DATA['full_ddx']['url']])
+            ingester.ingest(["https://opendap.jpl.nasa.gov/opendap/Afull_dataset.nc"])
         self.assertEqual(Dataset.objects.count(), initial_datasets_count + 1)
 
         with self.assertLogs(ingester.LOGGER, level=logging.INFO) as logger_cm:
-            ingester.ingest([self.TEST_DATA['full_ddx_2']['url']])
+            ingester.ingest(["https://opendap.jpl.nasa.gov/opendap/Afull_dataset.nc"])
 
-        self.assertTrue(logger_cm.records[0].msg.endswith('already exists in the database.'))
+        self.assertTrue(logger_cm.records[0].msg.endswith('already present in the database'))
         self.assertEqual(Dataset.objects.count(), initial_datasets_count + 1)
 
     def test_function_named_prepare_url(self):
@@ -722,7 +733,7 @@ class URLNameIngesterTestCase(django.test.TestCase):
         self.assertCountEqual(list(normalized_attributes.keys()),
                               ingester.DATASET_CUMULATIVE_PARAMETER_NAMES +
                               ingester.DATASET_PARAMETER_NAMES +
-                              ['geospaas_service_name', 'geospaas_service', 'entry_id'])
+                              ['geospaas_service_name', 'geospaas_service'])
         self.assertNotIn(None, normalized_attributes.values())
 
     def test_function_get_normalized_attributes_remss(self):
@@ -736,7 +747,7 @@ class URLNameIngesterTestCase(django.test.TestCase):
         self.assertCountEqual(list(normalized_attributes.keys()),
                               ingester.DATASET_CUMULATIVE_PARAMETER_NAMES +
                               ingester.DATASET_PARAMETER_NAMES +
-                              ['geospaas_service_name', 'geospaas_service', 'entry_id'])
+                              ['geospaas_service_name', 'geospaas_service'])
         self.assertNotIn(None, normalized_attributes.values())
 
     def test_function_get_normalized_attributes_jaxa(self):
@@ -750,7 +761,7 @@ class URLNameIngesterTestCase(django.test.TestCase):
         self.assertCountEqual(list(normalized_attributes.keys()),
                               ingester.DATASET_CUMULATIVE_PARAMETER_NAMES +
                               ingester.DATASET_PARAMETER_NAMES +
-                              ['geospaas_service_name', 'geospaas_service', 'entry_id'])
+                              ['geospaas_service_name', 'geospaas_service'])
         self.assertNotIn(None, normalized_attributes.values())
 
 

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -296,7 +296,7 @@ class DDXIngesterTestCase(django.test.TestCase):
 
     TEST_DATA = {
         'full_ddx': {
-            'url': "https://opendap.jpl.nasa.gov/opendap/Afull_dataset.nc.ddx",
+            'url': "https://opendap.jpl.nasa.gov/opendap/full_dataset.nc.ddx",
             'file_path': "data/opendap/full_ddx.xml"},
         'short_ddx': {
             'url': "https://test-opendap.com/short_dataset.nc.ddx",


### PR DESCRIPTION
closes #27 
closes #14 
@akorosov 
@aperrin66 
I put url into fields of raw_attribute for ddx ingester. for the copernicus, the things are done in the metanorm. 

Here once again we have first merge the pr of metanorm and then merge this pr in order to working properly.


Everything is ready with these files and I won't change them unless you tell me your review.