### PR TITLE
#37 dsp model usage is removed. The tests are directly use dataset models directly in their testing activities

### DIFF
--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -22,7 +22,7 @@ from geospaas.catalog.managers import (DAP_SERVICE_NAME, FILE_SERVICE_NAME,
                                        HTTP_SERVICE, HTTP_SERVICE_NAME,
                                        LOCAL_FILE_SERVICE, OPENDAP_SERVICE)
 from geospaas.catalog.models import (Dataset, DatasetURI, GeographicLocation,
-                                     Source, DatasetParameter)
+                                     Source)
 from geospaas.utils.utils import nansat_filename
 from geospaas.vocabularies.models import (DataCenter, Instrument,
                                           ISOTopicCategory, Location, Parameter, Platform)
@@ -151,8 +151,6 @@ class Ingester():
                 if params.count() > 1 and units is not None:
                     params = params.filter(units=units)
                 if params.count() >= 1:
-                    DatasetParameter.objects.get_or_create(
-                        dataset=dataset, parameter=params[0])
                     dataset.parameters.add(params[0])
 
         except django.db.utils.OperationalError:

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -688,12 +688,12 @@ class CopernicusODataIngesterTestCase(django.test.TestCase):
         created_dataset, created_dataset_uri = self.ingester._ingest_dataset(
             'https://scihub.copernicus.eu/full/$value', value_for_testing)
         self.assertEqual(Dataset.objects.count(), 1)
-        self.assertEqual(Dataset.objects.first().datasetparameter_set.count(), 1)
+        self.assertEqual(Dataset.objects.first().parameters.count(), 1)
         # the parameter that has added (by above variable of "value_for_testing") to the dataset
         # should be equal to the first object of parameter table
         # which is created by fixtures inside the database
         self.assertEqual(
-            Dataset.objects.first().datasetparameter_set.first().parameter, Parameter.objects.first())
+            Dataset.objects.first().parameters.first(), Parameter.objects.first())
         self.assertEqual(created_dataset, True)
         self.assertEqual(created_dataset_uri, True)
 
@@ -703,9 +703,9 @@ class CopernicusODataIngesterTestCase(django.test.TestCase):
             'https://scihub.copernicus.eu/full/$value', duplicate_value_for_testing)
 
         self.assertEqual(Dataset.objects.count(), 1)
-        self.assertEqual(Dataset.objects.first().datasetparameter_set.count(), 1)
+        self.assertEqual(Dataset.objects.first().parameters.count(), 1)
         self.assertEqual(
-            Dataset.objects.first().datasetparameter_set.first().parameter, Parameter.objects.first())
+            Dataset.objects.first().parameters.first(), Parameter.objects.first())
         self.assertEqual(created_dataset, False)
         self.assertEqual(created_dataset_uri, False)
 


### PR DESCRIPTION
dsp model usage is removed. The tests are directly use dataset models directly in their testing activities