### PR TITLE
WebDirectoryCrawler refactoring

### DIFF
--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -86,8 +86,8 @@ class WebDirectoryCrawler(Crawler):
     LOGGER = None
     EXCLUDE = None
 
-    YEAR_PATTERN = r'(\d{4})'
-    MONTH_PATTERN = r'(1[0-2]|0[1-9]|[1-9])'
+    YEAR_PATTERN = r'y?(\d{4})'
+    MONTH_PATTERN = r'm?(1[0-2]|0[1-9]|[1-9])'
     DAY_OF_MONTH_PATTERN = r'(3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9])'
     DAY_OF_YEAR_PATTERN = r'(36[0-6]|3[0-5]\d|[1-2]\d\d|0[1-9]\d|00[1-9]|[1-9]\d|0[1-9]|[1-9])'
 

--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -272,7 +272,7 @@ class WebDirectoryCrawler(Crawler):
         return resource_url
 
 
-class HTTPDirectoryCrawler(WebDirectoryCrawler):
+class HTMLDirectoryCrawler(WebDirectoryCrawler):
     """"""
 
     FOLDERS_SUFFIXES = None
@@ -317,7 +317,7 @@ class HTTPDirectoryCrawler(WebDirectoryCrawler):
         return self._prepend_parent_path(stripped_folder_path, self._get_links(html))
 
 
-class OpenDAPCrawler(HTTPDirectoryCrawler):
+class OpenDAPCrawler(HTMLDirectoryCrawler):
     """
     Crawler for harvesting the data of OpenDAP
     """
@@ -327,7 +327,7 @@ class OpenDAPCrawler(HTTPDirectoryCrawler):
     EXCLUDE = ['?']
 
 
-class ThreddsCrawler(HTTPDirectoryCrawler):
+class ThreddsCrawler(HTMLDirectoryCrawler):
     """
     Crawler for harvesting the data which are provided by Thredds
     """

--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -252,7 +252,7 @@ class WebDirectoryCrawler(Crawler):
         self.LOGGER.info("Looking for resources in '%s'...", folder_path)
         for path in self._list_folder_contents(folder_path):
             # Select paths which do not contain any of the self.excludes strings
-            if all(map(lambda s, p=path: s not in p, self.excludes)):
+            if all([excluded_string not in path for excluded_string in self.excludes]):
                 if self._is_folder(path):
                     self._add_folder_to_process(path)
                 elif self._is_file(path):

--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -235,7 +235,7 @@ class WebDirectoryCrawler(Crawler):
         self.LOGGER.info("Looking for resources in '%s'...", folder_path)
         for path in self._list_folder_contents(folder_path):
             # Select paths which do not contain any of the self.excludes strings
-            if all([excluded_string not in path for excluded_string in self.excludes]):
+            if all(excluded_string not in path for excluded_string in self.excludes):
                 if self._is_folder(path):
                     self._add_folder_to_process(path)
                 elif self._is_file(path):

--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -97,10 +97,6 @@ class WebDirectoryCrawler(Crawler):
         f'^.*/{YEAR_PATTERN}/{MONTH_PATTERN}/{DAY_OF_MONTH_PATTERN}/.*$')
     DAY_OF_YEAR_MATCHER = re.compile(f'^.*/{YEAR_PATTERN}/{DAY_OF_YEAR_PATTERN}(/.*)?$')
 
-    TIMESTAMP_MATCHER = re.compile(
-        r'(?P<date>(\d{4})(1[0-2]|0[1-9]|[1-9])(3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9]))_?'
-        r'(?P<time>(2[0-3]|[0-1]\d|\d)([0-5]\d|\d)(6[0-1]|[0-5]\d|\d))')
-
     def __init__(self, root_url, time_range=(None, None), excludes=None):
         """
         `root_url` is the URL of the data repository to explore.
@@ -192,18 +188,6 @@ class WebDirectoryCrawler(Crawler):
 
         return (folder_coverage_start, folder_coverage_stop)
 
-    @classmethod
-    def _dataset_timestamp(cls, dataset_name):
-        """Tries to find a timestamp in the dataset's name"""
-        timestamp_match = cls.TIMESTAMP_MATCHER.search(dataset_name)
-        if timestamp_match:
-            return datetime.strptime(
-                timestamp_match['date'] + timestamp_match['time'],
-                '%Y%m%d%H%M%S'
-            )
-        else:
-            return None
-
     def _intersects_time_range(self, start_time=None, stop_time=None):
         """
         Return True if either of these conditions is met:
@@ -232,13 +216,12 @@ class WebDirectoryCrawler(Crawler):
         Add a URL to the list of URLs returned by the crawler after
         checking that it fits inside the crawler's time range.
         """
-        if self._intersects_time_range(*(self._dataset_timestamp(path),) * 2):
-            resource_url = urljoin(self.base_url, path)
-            download_url = self.get_download_url(resource_url)
-            if download_url is not None:
-                if download_url not in self._urls:
-                    self.LOGGER.debug("Adding '%s' to the list of resources.", download_url)
-                    self._urls.append(download_url)
+        resource_url = urljoin(self.base_url, path)
+        download_url = self.get_download_url(resource_url)
+        if download_url is not None:
+            if download_url not in self._urls:
+                self.LOGGER.debug("Adding '%s' to the list of resources.", download_url)
+                self._urls.append(download_url)
 
     def _add_folder_to_process(self, path):
         """Add a folder to the list of folder which will be explored later"""

--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -105,7 +105,7 @@ class WebDirectoryCrawler(Crawler):
         """
         `root_url` is the URL of the data repository to explore.
         `time_range` is a 2-tuple of datetime.datetime objects defining the time range
-        of the datasets returned the crawler.
+        of the datasets returned by the crawler.
         `excludes` is the list of string that are the associated url is ignored during
         the harvesting process if these strings are found in the crawled url.
         """

--- a/geospaas_harvesting/harvest.py
+++ b/geospaas_harvesting/harvest.py
@@ -233,6 +233,7 @@ def main():
 
     LOGGER.info('Finished updating vocabularies')
     processes_number = len(config['harvesters'])
+    endless = config.get('endless', False)
     try:
         with multiprocessing.Pool(processes_number, initializer=init_worker) as pool:
             results = {}
@@ -255,10 +256,12 @@ def main():
                                 config.get('dump_on_interruption', True)
                             )
                         )
-                if not config.get('endless', False):
+                if not endless:
                     break
                 time.sleep(config.get('poll_interval', 600))
-            LOGGER.error("All harvester processes encountered errors")
+
+            if endless:
+                LOGGER.error("All harvester processes encountered errors")
             pool.close()
             pool.join()
     except KeyboardInterrupt:

--- a/geospaas_harvesting/harvesters.py
+++ b/geospaas_harvesting/harvesters.py
@@ -146,10 +146,13 @@ class FTPHarvester(WebDirectoryHarvester):
     ingester = ingesters.URLNameIngester
     def _create_crawlers(self):
         return [
-            crawlers.FTPCrawler(root_url=url,
-                                username=self.config.get('username', None),
-                                password=self.config.get('password'),
-                                fileformat=self.config.get('fileformat', None),)
+            crawlers.FTPCrawler(
+                root_url=url,
+                username=self.config.get('username', None),
+                password=self.config.get('password'),
+                files_suffixes=self.config.get('fileformat', None),
+                time_range=(self.get_time_range())
+            )
             for url in self.config['urls']
         ]
 

--- a/geospaas_harvesting/harvesters.py
+++ b/geospaas_harvesting/harvesters.py
@@ -151,7 +151,8 @@ class FTPHarvester(WebDirectoryHarvester):
                 username=self.config.get('username', None),
                 password=self.config.get('password'),
                 files_suffixes=self.config.get('fileformat', None),
-                time_range=(self.get_time_range())
+                time_range=(self.get_time_range()),
+                excludes=self.config.get('excludes', None)
             )
             for url in self.config['urls']
         ]

--- a/tests/data/configuration_files/harvest_ok.yml
+++ b/tests/data/configuration_files/harvest_ok.yml
@@ -1,4 +1,5 @@
 ---
+endless: True
 harvesters:
   test:
     class: 'TestHarvester'

--- a/tests/test_crawlers.py
+++ b/tests/test_crawlers.py
@@ -71,8 +71,8 @@ class WebDirectoryCrawlerTestCase(unittest.TestCase):
         self.assertEqual(crawler.get_download_url('foo'), 'foo')
 
 
-class HTTPDirectoryCrawlerTestCase(unittest.TestCase):
-    """Tests for the HTTPDirectoryCrawler crawler"""
+class HTMLDirectoryCrawlerTestCase(unittest.TestCase):
+    """Tests for the HTMLDirectoryCrawler crawler"""
 
     def test_prepend_parent_path(self):
         """
@@ -81,7 +81,7 @@ class HTTPDirectoryCrawlerTestCase(unittest.TestCase):
         parent_path = '/foo'
         paths = ['/foo/bar', 'baz']
         self.assertEqual(
-            crawlers.HTTPDirectoryCrawler._prepend_parent_path(parent_path, paths),
+            crawlers.HTMLDirectoryCrawler._prepend_parent_path(parent_path, paths),
             ['/foo/bar', '/foo/baz']
         )
 

--- a/tests/test_crawlers.py
+++ b/tests/test_crawlers.py
@@ -675,8 +675,8 @@ class FTPCrawlerTestCase(unittest.TestCase):
 
     @mock.patch('geospaas_harvesting.crawlers.ftplib.FTP', autospec=True)
     def test_ftp_correct_navigation(self, mock_ftp):
-        """ shall categorize the specific file names (based on specific 'fileformat' which is
-        revealed in the configuration file) as well as folder(s) inside the ftp resource """
+        """check that file URLs and folders paths are added to the right stacks"""
+
         test_crawler = crawlers.FTPCrawler('ftp://foo', files_suffixes='.gz')
         test_crawler.ftp.nlst.return_value = ['file1.gz', 'folder_name', 'file3.bb', 'file2.gz', ]
         test_crawler.ftp.cwd = self.emulate_cwd_of_ftp
@@ -691,11 +691,11 @@ class FTPCrawlerTestCase(unittest.TestCase):
 
     @mock.patch('geospaas_harvesting.crawlers.ftplib.FTP.login')
     def test_ftp_correct_exception(self, mock_ftp):
-        """ shall return the costume 'ConnectionError'
-         instead of 'ftplib.error_perm' in order to continue the harvesting process in the case of
-         redundant or repetitive login attempt(s)
-         after the first login attempt. "nlst" is placed after "login" in source code. So reach "nlst"
-         means passing the login code. """
+        """set_initial_state() should not raise an error in case of
+        503 or 230 responses from FTP.login(), but it should for
+        other error codes.
+        """
+
         test_crawler = crawlers.FTPCrawler(
             'ftp://', username="d", password="d", files_suffixes='.gz')
 

--- a/tests/test_daemon_script.py
+++ b/tests/test_daemon_script.py
@@ -40,6 +40,7 @@ class ConfigurationTestCase(unittest.TestCase):
         self.assertDictEqual(
             configuration._data,
             {
+                'endless': True,
                 'harvesters': {
                     'test': {
                         'class': 'TestHarvester',
@@ -154,7 +155,7 @@ class ConfigurationTestCase(unittest.TestCase):
         with self.assertLogs(harvest.LOGGER):
             configuration = harvest.Configuration(CONFIGURATION_FILES['ok'])
         self.assertTrue(callable(getattr(configuration, '__len__')))
-        self.assertEqual(len(configuration), 2)
+        self.assertEqual(len(configuration), 3)
 
     def test_iterable(self):
         """Configuration objects must be iterable"""
@@ -162,6 +163,7 @@ class ConfigurationTestCase(unittest.TestCase):
             configuration = harvest.Configuration(CONFIGURATION_FILES['ok'])
         self.assertTrue(callable(getattr(configuration, '__iter__')))
         config_iterator = iter(configuration)
+        self.assertEqual(next(config_iterator), 'endless')
         self.assertEqual(next(config_iterator), 'harvesters')
         self.assertEqual(next(config_iterator), 'poll_interval')
         with self.assertRaises(StopIteration):

--- a/tests/test_harvesters.py
+++ b/tests/test_harvesters.py
@@ -171,7 +171,9 @@ class ChildHarvestersTestCase(unittest.TestCase):
 
     def test_ftp_harvester(self):
         """The FTP harvester has the correct crawler and ingester"""
-        harvester = harvesters.FTPHarvester(urls=['ftp://'], max_fetcher_threads=1, max_db_threads=1)
+        with mock.patch.object(crawlers.FTPCrawler, '__init__', return_value=None):
+            harvester = harvesters.FTPHarvester(
+                urls=['ftp://'], max_fetcher_threads=1, max_db_threads=1)
         self.assertIsInstance(harvester._current_crawler, crawlers.FTPCrawler)
         self.assertIsInstance(harvester._ingester, ingesters.URLNameIngester)
 
@@ -189,9 +191,9 @@ class ChildHarvestersTestCase(unittest.TestCase):
         harvester = harvesters.OSISAFHarvester(urls=[''], max_fetcher_threads=1, max_db_threads=1,
                                                excludes=['ease', '_sh_polstere', ])
         self.assertListEqual(harvester._current_crawler.excludes,
-                             ['/thredds/', 'http', 'ease', '_sh_polstere'])
+                             crawlers.ThreddsCrawler.EXCLUDE + ['ease', '_sh_polstere'])
         harvester = harvesters.OSISAFHarvester(urls=[''], max_fetcher_threads=1, max_db_threads=1)
-        self.assertListEqual(harvester._current_crawler.excludes, ['/thredds/', 'http', ])
+        self.assertListEqual(harvester._current_crawler.excludes, crawlers.ThreddsCrawler.EXCLUDE)
 
         with self.assertRaises(HarvesterConfigurationError):
             harvester = harvesters.OSISAFHarvester(urls=[''], max_fetcher_threads=1, max_db_threads=1,


### PR DESCRIPTION
Resolves #46 

This started as an attempt to make time range restrictions (and all WebDirectoryCrawler functionalities) work for the FTPCrawler.

I ended up rewriting the WebDirectoryCrawler in a way that makes it easier to inherit from and benefit from its functionalities.
I added an intermediate HTMLDirectoryCrawler class from which the OpenDAPCrawler and the ThreddsCrawler inherit.

I also removed the part that filtered on dataset timestamps (in crawlers), because the format of timestamps is not consistent across providers, and the dataset time coverage cannot always be deducted from them. So the maximum precision for time filtering in WebDirectoryCrawlers is at the folder level (if the datasets are sorted into one folder per month, then the maximum precision will be a month), which is enough for crawlers.

The main result of all this is that the `time_range` and `excludes` arguments can now be used for FTPCrawlers.