### PR TITLE
Refactor Ingester to use not only download urls

### DIFF
--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -223,10 +223,12 @@ class Ingester():
         # It's important to close the database connection after the thread has done its work
         django.db.connection.close()
 
-    def ingest(self, datasets_info, *args, **kwargs):
+    def ingest(self, datasets_to_ingest, *args, **kwargs):
         """
-        `urls` should be an iterable. This method iterates over it and ingests the datasets at these
-        URLs into the database.
+        `datasets_to_ingest` should be an iterable containing information about the datasets to
+        ingest. The nature of this information depends on the crawler and the ingester, but it
+        usually is the URL where the dataset can be downloaded.
+        This method iterates over datasets_to_ingest and ingests the datasets into the database.
         To be efficient, the tasks of getting the datasets' attributes from their URLs and inserting
         them in the database are multi-threaded.
 
@@ -260,7 +262,7 @@ class Ingester():
                     thread_name_prefix=self.__class__.__name__ + '.attr') as attr_executor:
                 try:
                     attr_futures = []
-                    for dataset_info in datasets_info:
+                    for dataset_info in datasets_to_ingest:
                         attr_futures.append(attr_executor.submit(
                             self._thread_get_normalized_attributes, dataset_info, *args, *kwargs))
                 except KeyboardInterrupt:

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -67,6 +67,12 @@ class IngesterTestCase(django.test.TransactionTestCase):
         self._create_dummy_dataset_uri(uri, dataset)
         self.assertTrue(self.ingester._uri_exists(uri))
 
+    def test_get_download_url(self):
+        """get_download_url() should return the download URL from the
+        information provided by a crawler.
+        """
+        self.assertEqual(self.ingester.get_download_url('url'), 'url')
+
     def test_get_normalized_attributes_must_be_implemented(self):
         """An error must be raised if the _get_normalized_attributes() method is not implemented"""
         with self.assertRaises(NotImplementedError), self.assertLogs(self.ingester.LOGGER):
@@ -151,7 +157,7 @@ class IngesterTestCase(django.test.TransactionTestCase):
             mock_normalize.side_effect = TypeError
             with self.assertLogs(self.ingester.LOGGER, level=logging.ERROR) as logger_cm:
                 self.ingester._thread_get_normalized_attributes('some_url')
-            self.assertEqual(logger_cm.records[0].message, "Could not get metadata from 'some_url'")
+            self.assertEqual(logger_cm.records[0].message, "Could not get metadata for 'some_url'")
 
     def test_fetching_threads_stop_on_keyboard_interrupt(self):
         """


### PR DESCRIPTION
This is preparation to adding support for Creodias (#57).

The base Ingester class is modified so that it can work with crawlers which return the raw attributes of the datasets, not just the download URL. This will be useful when harvesting from APIs which can return lists of metadata about datasets.

I also made a small modification, so that scheduled threads are actually cancelled when the main process is stopped.