### PR TITLE
Deal with authentication in redirections

### DIFF
--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -17,6 +17,8 @@ from urllib.parse import urljoin, urlparse
 import feedparser
 import requests
 
+import geospaas_harvesting.utils as utils
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
@@ -41,7 +43,7 @@ class Crawler():
         html_page = ''
         cls.LOGGER.debug("Getting page: '%s'", url)
         try:
-            response = requests.get(url, **request_parameters or {})
+            response = utils.http_get(url, **request_parameters or {})
             response.raise_for_status()
             html_page = response.text
         except requests.exceptions.RequestException:

--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -43,7 +43,7 @@ class Crawler():
         html_page = ''
         cls.LOGGER.debug("Getting page: '%s'", url)
         try:
-            response = utils.http_get(url, **request_parameters or {})
+            response = utils.http_request('GET', url, **request_parameters or {})
             response.raise_for_status()
             html_page = response.text
         except requests.exceptions.RequestException:

--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -22,6 +22,7 @@ from django.contrib.gis.geos import GEOSGeometry, LineString
 from django.contrib.gis.geos.point import Point
 
 import pythesint as pti
+import geospaas_harvesting.utils as utils
 from geospaas.catalog.managers import (DAP_SERVICE_NAME, FILE_SERVICE_NAME,
                                        HTTP_SERVICE, HTTP_SERVICE_NAME,
                                        LOCAL_FILE_SERVICE, OPENDAP_SERVICE)
@@ -407,7 +408,7 @@ class DDXIngester(MetanormIngester):
         """Get normalized metadata from the DDX info of the dataset located at the provided URL"""
         prepared_url = self.prepare_url(dataset_info)
         # Get the metadata from the dataset as an XML tree
-        stream = io.BytesIO(requests.get(prepared_url, stream=True).content)
+        stream = io.BytesIO(utils.http_get(prepared_url, stream=True).content)
         # Get all the global attributes of the Dataset into a dictionary
         extracted_attributes = self._extract_attributes(
             ET.parse(stream).getroot())
@@ -456,7 +457,7 @@ class CopernicusODataIngester(MetanormIngester):
         """Get the raw JSON metadata from a Copernicus OData URL"""
         try:
             metadata_url = self._build_metadata_url(url)
-            stream = requests.get(metadata_url, auth=self._credentials, stream=True).content
+            stream = utils.http_get(metadata_url, auth=self._credentials, stream=True).content
         except (requests.exceptions.RequestException, ValueError):
             self.LOGGER.error("Could not get metadata for the dataset located at '%s'", url,
                               exc_info=True)

--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -408,7 +408,7 @@ class DDXIngester(MetanormIngester):
         """Get normalized metadata from the DDX info of the dataset located at the provided URL"""
         prepared_url = self.prepare_url(dataset_info)
         # Get the metadata from the dataset as an XML tree
-        stream = io.BytesIO(utils.http_get(prepared_url, stream=True).content)
+        stream = io.BytesIO(utils.http_request('GET', prepared_url, stream=True).content)
         # Get all the global attributes of the Dataset into a dictionary
         extracted_attributes = self._extract_attributes(
             ET.parse(stream).getroot())
@@ -457,7 +457,8 @@ class CopernicusODataIngester(MetanormIngester):
         """Get the raw JSON metadata from a Copernicus OData URL"""
         try:
             metadata_url = self._build_metadata_url(url)
-            stream = utils.http_get(metadata_url, auth=self._credentials, stream=True).content
+            stream = utils.http_request(
+                'GET', metadata_url, auth=self._credentials, stream=True).content
         except (requests.exceptions.RequestException, ValueError):
             self.LOGGER.error("Could not get metadata for the dataset located at '%s'", url,
                               exc_info=True)

--- a/geospaas_harvesting/utils.py
+++ b/geospaas_harvesting/utils.py
@@ -1,0 +1,38 @@
+"""Utilities module for geospaas_harvesting"""
+
+import requests
+from urllib.parse import urlparse
+
+
+class TrustDomainSession(requests.Session):
+    """Session class which allows keeping authentication headers in
+    case of redirection to the same domain
+    """
+
+    def should_strip_auth(self, old_url, new_url):
+        """Keep the authentication header when redirecting to a
+        different host in the same domain, for example from
+        "scihub.copernicus.eu" to "apihub.copernicus.eu".
+        If not in this case, defer to the parent class.
+        """
+        old_split_hostname = urlparse(old_url).hostname.split('.')
+        new_split_hostname = urlparse(new_url).hostname.split('.')
+        if (len(old_split_hostname) == len(new_split_hostname) > 2
+                and old_split_hostname[1:] == new_split_hostname[1:]):
+            return False
+        else:
+            return super().should_strip_auth(old_url, new_url)
+
+
+def http_get(*args, **kwargs):
+    """Wrapper around requests.get() which runs the HTTP request inside
+    a session if authentication is provided. This makes it possible to
+    follow redirections inside the same domain.
+    """
+    auth = kwargs.pop('auth', None)
+    if auth:
+        with TrustDomainSession() as session:
+            session.auth = auth
+            return session.get(*args, **kwargs)
+    else:
+        return requests.get(*args, **kwargs)

--- a/geospaas_harvesting/utils.py
+++ b/geospaas_harvesting/utils.py
@@ -24,15 +24,15 @@ class TrustDomainSession(requests.Session):
             return super().should_strip_auth(old_url, new_url)
 
 
-def http_get(*args, **kwargs):
-    """Wrapper around requests.get() which runs the HTTP request inside
-    a session if authentication is provided. This makes it possible to
-    follow redirections inside the same domain.
+def http_request(http_method, *args, **kwargs):
+    """Wrapper around requests.request() which runs the HTTP request
+    inside a TrustDomainSession if authentication is provided. This
+    makes it possible to follow redirections inside the same domain.
     """
     auth = kwargs.pop('auth', None)
     if auth:
         with TrustDomainSession() as session:
             session.auth = auth
-            return session.get(*args, **kwargs)
+            return session.request(http_method, *args, **kwargs)
     else:
-        return requests.get(*args, **kwargs)
+        return requests.request(http_method, *args, **kwargs)

--- a/tests/test_crawlers.py
+++ b/tests/test_crawlers.py
@@ -393,8 +393,11 @@ class OpenDAPCrawlerTestCase(unittest.TestCase):
             'file_path': None}
     }
 
-    def requests_get_side_effect(self, url):
+    def request_side_effect(self, method, url):
         """Side effect function used to mock calls to requests.get().text"""
+        if method != 'GET':
+            return None
+
         data_file_relative_path = None
         for test_data in self.TEST_DATA.values():
             if url in test_data['urls']:
@@ -417,16 +420,16 @@ class OpenDAPCrawlerTestCase(unittest.TestCase):
         return response
 
     def setUp(self):
-        # Mock requests.get()
-        self.patcher_requests_get = mock.patch.object(crawlers.requests, 'get')
-        self.mock_requests_get = self.patcher_requests_get.start()
-        self.mock_requests_get.side_effect = self.requests_get_side_effect
+        # Mock requests.request()
+        self.patcher_request = mock.patch.object(crawlers.requests, 'request')
+        self.mock_request = self.patcher_request.start()
+        self.mock_request.side_effect = self.request_side_effect
 
         # Initialize a list of opened files which will be closed in tearDown()
         self.opened_files = []
 
     def tearDown(self):
-        self.patcher_requests_get.stop()
+        self.patcher_request.stop()
         # Close any files opened during the test
         for opened_file in self.opened_files:
             opened_file.close()

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -323,8 +323,10 @@ class DDXIngesterTestCase(django.test.TestCase):
             'file_path': "data/opendap/ddx_no_ns.xml"},
     }
 
-    def requests_get_side_effect(self, url, **kwargs):
+    def request_side_effect(self, method, url, **kwargs):
         """Side effect function used to mock calls to requests.get().text"""
+        if method != 'GET':
+            return None
         data_file_relative_path = None
         for test_data in self.TEST_DATA.values():
             if url == test_data['url']:
@@ -350,13 +352,13 @@ class DDXIngesterTestCase(django.test.TestCase):
         self.mock_param_count = self.patcher_param_count.start()
         self.mock_param_count.return_value = 2
         # Mock requests.get()
-        self.patcher_requests_get = mock.patch('geospaas_harvesting.ingesters.requests.get')
-        self.mock_requests_get = self.patcher_requests_get.start()
-        self.mock_requests_get.side_effect = self.requests_get_side_effect
+        self.patcher_request = mock.patch('geospaas_harvesting.ingesters.requests.request')
+        self.mock_request = self.patcher_request.start()
+        self.mock_request.side_effect = self.request_side_effect
         self.opened_files = []
 
     def tearDown(self):
-        self.patcher_requests_get.stop()
+        self.patcher_request.stop()
         self.patcher_param_count.stop()
         # Close any files opened during the test
         for opened_file in self.opened_files:
@@ -547,8 +549,10 @@ class CopernicusODataIngesterTestCase(django.test.TestCase):
             'file_path': "data/copernicus_opensearch/full.json"}
     }
 
-    def requests_get_side_effect(self, url, **kwargs):  # pylint: disable=unused-argument
+    def request_side_effect(self, method, url, **kwargs):  # pylint: disable=unused-argument
         """Side effect function used to mock calls to requests.get().text"""
+        if method != 'GET':
+            return None
         data_file_relative_path = None
         for test_data in self.TEST_DATA.values():
             if url == test_data['url']:
@@ -573,9 +577,9 @@ class CopernicusODataIngesterTestCase(django.test.TestCase):
     def setUp(self):
         self.ingester = ingesters.CopernicusODataIngester()
         # Mock requests.get()
-        self.patcher_requests_get = mock.patch.object(ingesters.requests, 'get')
-        self.mock_requests_get = self.patcher_requests_get.start()
-        self.mock_requests_get.side_effect = self.requests_get_side_effect
+        self.patcher_request = mock.patch.object(ingesters.requests, 'request')
+        self.mock_request = self.patcher_request.start()
+        self.mock_request.side_effect = self.request_side_effect
         self.opened_files = []
 
         self.patcher_param_count = mock.patch.object(Parameter.objects, 'count')
@@ -583,7 +587,7 @@ class CopernicusODataIngesterTestCase(django.test.TestCase):
         self.mock_param_count.return_value = 2
 
     def tearDown(self):
-        self.patcher_requests_get.stop()
+        self.patcher_request.stop()
         self.patcher_param_count.stop()
         # Close any files opened during the test
         for opened_file in self.opened_files:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,51 @@
+"""Tests for the geospaas_harvesting.utils module"""
+
+import unittest
+import unittest.mock as mock
+
+import geospaas_harvesting.utils as utils
+
+class UtilsTestCase(unittest.TestCase):
+    """Tests for utilities"""
+
+    def test_should_strip_auth(self):
+        """The authentication headers should be stripped if a
+        redirection outside of the current domain happens
+        """
+        with utils.TrustDomainSession() as session:
+            self.assertFalse(session.should_strip_auth('https://scihub.copernicus.eu/foo/bar',
+                                                       'https://apihub.copernicus.eu/foo/bar'))
+
+            self.assertFalse(session.should_strip_auth('https://scihub.copernicus.eu/foo/bar',
+                                                       'https://scihub.copernicus.eu/baz'))
+
+            self.assertFalse(session.should_strip_auth('http://scihub.copernicus.eu:80/foo/bar',
+                                                       'https://scihub.copernicus.eu:443/foo/bar'))
+
+            self.assertTrue(session.should_strip_auth('https://scihub.copernicus.eu/foo/bar',
+                                                      'https://www.website.com/foo/bar'))
+
+            self.assertTrue(session.should_strip_auth('https://scihub.copernicus.eu/foo/bar',
+                                                      'https://foo.com/bar'))
+
+    def test_http_get_with_auth(self):
+        """If the `auth` argument is provided, the request should be
+        executed inside a TrustDomainSession
+        """
+        with mock.patch('requests.Session.get', return_value='response') as mock_get:
+            self.assertEqual(
+                utils.http_get('url', stream=False, auth=('username', 'password')),
+                'response'
+            )
+            mock_get.assert_called_once_with('url', stream=False)
+
+    def test_http_get_without_auth(self):
+        """If the `auth` argument is not provided, the request should
+        simply be executed using requests.get()
+        """
+        with mock.patch('requests.get', return_value='response') as mock_get:
+            self.assertEqual(
+                utils.http_get('url', stream=True),
+                'response'
+            )
+            mock_get.assert_called_once_with('url', stream=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,24 +28,24 @@ class UtilsTestCase(unittest.TestCase):
             self.assertTrue(session.should_strip_auth('https://scihub.copernicus.eu/foo/bar',
                                                       'https://foo.com/bar'))
 
-    def test_http_get_with_auth(self):
+    def test_http_request_with_auth(self):
         """If the `auth` argument is provided, the request should be
         executed inside a TrustDomainSession
         """
-        with mock.patch('requests.Session.get', return_value='response') as mock_get:
+        with mock.patch('requests.Session.request', return_value='response') as mock_request:
             self.assertEqual(
-                utils.http_get('url', stream=False, auth=('username', 'password')),
+                utils.http_request('GET', 'url', stream=False, auth=('username', 'password')),
                 'response'
             )
-            mock_get.assert_called_once_with('url', stream=False)
+            mock_request.assert_called_once_with('GET', 'url', stream=False)
 
-    def test_http_get_without_auth(self):
+    def test_http_request_without_auth(self):
         """If the `auth` argument is not provided, the request should
         simply be executed using requests.get()
         """
-        with mock.patch('requests.get', return_value='response') as mock_get:
+        with mock.patch('requests.request', return_value='response') as mock_request:
             self.assertEqual(
-                utils.http_get('url', stream=True),
+                utils.http_request('GET', 'url', stream=True),
                 'response'
             )
-            mock_get.assert_called_once_with('url', stream=True)
+            mock_request.assert_called_once_with('GET', 'url', stream=True)


### PR DESCRIPTION
Resolves #91 

Add a `utils` module containing:
- a `TrustDomainSession` class which does not strip authentication headers when a redirection happens inside the same domain.
- an `http_get` function which executes requests with authentication inside such a session. 