### PR TITLE
Refactor urls check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM ${BASE_IMAGE} as base
 ARG METANORM_VERSION
 RUN pip install --no-cache-dir \
     https://github.com/nansencenter/metanorm/releases/download/${METANORM_VERSION}/metanorm-${METANORM_VERSION}-py3-none-any.whl \
+    feedparser==5.2.1 \
     graypy==2.1.0 \
-    feedparser==5.2.1
+    requests_oauthlib==1.3
 
 FROM base
 

--- a/geospaas_harvesting/check.yml
+++ b/geospaas_harvesting/check.yml
@@ -1,29 +1,30 @@
----
-scihub:
-  url: 'https://scihub.copernicus.eu/'
-  username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
-  password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
-apihub:
-  url: 'https://apihub.copernicus.eu/'
-  username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
-  password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
-podaac:
-  url: 'https://opendap.jpl.nasa.gov/opendap/'
-cmems:
-  url: 'ftp://nrt.cmems-du.eu/'
-  username: !ENV 'CMEMS_USERNAME'
-  password: !ENV 'CMEMS_PASSWORD'
-jaxa:
-  url: 'ftp://ftp.gportal.jaxa.jp/'
-  username: !ENV 'JAXA_USERNAME'
-  password: !ENV 'JAXA_PASSWORD'
-creodias:
-  url: 'https://zipper.creodias.eu/'
-  username: !ENV 'CREODIAS_USERNAME'
-  password: !ENV 'CREODIAS_PASSWORD'
-  token_url: 'https://auth.creodias.eu/auth/realms/DIAS/protocol/openid-connect/token'
-  client_id: 'CLOUDFERRO_PUBLIC'
-  throttle: 1
-noaa_hycom:
-  url: 'ftp://ftp.opc.ncep.noaa.gov/'
-...
+# Example providers configuration file for the verify_urls module
+# ---
+# scihub:
+#   url: 'https://scihub.copernicus.eu/'
+#   username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
+#   password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
+# apihub:
+#   url: 'https://apihub.copernicus.eu/'
+#   username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
+#   password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
+# podaac:
+#   url: 'https://opendap.jpl.nasa.gov/opendap/'
+# cmems:
+#   url: 'ftp://nrt.cmems-du.eu/'
+#   username: !ENV 'CMEMS_USERNAME'
+#   password: !ENV 'CMEMS_PASSWORD'
+# jaxa:
+#   url: 'ftp://ftp.gportal.jaxa.jp/'
+#   username: !ENV 'JAXA_USERNAME'
+#   password: !ENV 'JAXA_PASSWORD'
+# creodias:
+#   url: 'https://zipper.creodias.eu/'
+#   username: !ENV 'CREODIAS_USERNAME'
+#   password: !ENV 'CREODIAS_PASSWORD'
+#   token_url: 'https://auth.creodias.eu/auth/realms/DIAS/protocol/openid-connect/token'
+#   client_id: 'CLOUDFERRO_PUBLIC'
+#   throttle: 1
+# noaa_hycom:
+#   url: 'ftp://ftp.opc.ncep.noaa.gov/'
+# ...

--- a/geospaas_harvesting/check.yml
+++ b/geospaas_harvesting/check.yml
@@ -1,0 +1,25 @@
+---
+scihub:
+  url: 'https://scihub.copernicus.eu/'
+  username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
+  password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
+podaac:
+  url: 'https://opendap.jpl.nasa.gov/opendap/'
+cmems:
+  url: 'ftp://nrt.cmems-du.eu/'
+  username: !ENV 'CMEMS_USERNAME'
+  password: !ENV 'CMEMS_PASSWORD'
+jaxa:
+  url: 'ftp://ftp.gportal.jaxa.jp/'
+  username: !ENV 'JAXA_USERNAME'
+  password: !ENV 'JAXA_PASSWORD'
+creodias:
+  url: 'https://zipper.creodias.eu/'
+  username: !ENV 'CREODIAS_USERNAME'
+  password: !ENV 'CREODIAS_PASSWORD'
+  token_url: 'https://auth.creodias.eu/auth/realms/DIAS/protocol/openid-connect/token'
+  client_id: 'CLOUDFERRO_PUBLIC'
+  throttle: 1
+noaa_hycom:
+  url: 'ftp://ftp.opc.ncep.noaa.gov/'
+...

--- a/geospaas_harvesting/check.yml
+++ b/geospaas_harvesting/check.yml
@@ -25,6 +25,7 @@
 #   token_url: 'https://auth.creodias.eu/auth/realms/DIAS/protocol/openid-connect/token'
 #   client_id: 'CLOUDFERRO_PUBLIC'
 #   throttle: 1
+#   auth_renew: 36000
 # noaa_hycom:
 #   url: 'ftp://ftp.opc.ncep.noaa.gov/'
 # ...

--- a/geospaas_harvesting/check.yml
+++ b/geospaas_harvesting/check.yml
@@ -3,6 +3,10 @@ scihub:
   url: 'https://scihub.copernicus.eu/'
   username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
   password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
+apihub:
+  url: 'https://apihub.copernicus.eu/'
+  username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
+  password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
 podaac:
   url: 'https://opendap.jpl.nasa.gov/opendap/'
 cmems:

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -1,12 +1,12 @@
 """ Verification module. """
 import concurrent.futures
-import functools
 import logging
 import os
 import sys
 import time
+from contextlib import closing
 from datetime import datetime
-from threading import Lock
+from threading import BoundedSemaphore, Lock
 
 import django
 import oauthlib.oauth2
@@ -19,26 +19,30 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'geospaas_harvesting.settings')
 django.setup()
 from geospaas.catalog.models import DatasetURI
 
-
 logging.basicConfig(level=logging.INFO)
 
 
-def throttle(period):
-    """Decorator builder. Returns a decorator which prevents a function
-    from being called more than once every `period` seconds
+class BoundedThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
+    """A ThreadPoolExecutor which has a limit on the number of jobs
+    which can be submitted at once
     """
-    def decorator_throttle(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            if wrapper.last_call:
-                time_since_last_call = time.monotonic() - wrapper.last_call
-                if time_since_last_call < period:
-                    time.sleep(period - time_since_last_call)
-            wrapper.last_call = time.monotonic()
-            return func(*args, **kwargs)
-        wrapper.last_call = 0
-        return wrapper
-    return decorator_throttle
+
+    def __init__(self, *args, queue_limit=10000, **kwargs):
+        self.semaphore = BoundedSemaphore(kwargs.get('max_workers', 0) + queue_limit)
+        super().__init__(*args, **kwargs)
+
+    def submit(self, fn, *args, **kwargs):
+        self.semaphore.acquire()
+        try:
+            future = super().submit(fn, *args, **kwargs)
+        except:
+            # if anything goes, wrong, we need to release the semaphore
+            self.semaphore.release()
+            raise
+        else:
+            # release the semaphore once the thread ends
+            future.add_done_callback(lambda x: self.semaphore.release())
+            return future
 
 
 def build_oauth2(username, password, token_url, client_id):
@@ -69,7 +73,8 @@ def get_auth(attributes):
 
 
 def read_config(config_path):
-    """Reads the configuration file and build a providers dictionary
+    """Reads the configuration file and builds a dictionary of
+    providers
     """
     yaml.SafeLoader.add_constructor('!ENV', lambda loader, node: os.getenv(node.value))
     with open(config_path, 'r') as config_file:
@@ -77,41 +82,37 @@ def read_config(config_path):
 
     providers = {}
     for provider, attributes in config.items():
-
-        throttle_period = attributes.get('throttle')
-        checker_function = throttle(throttle_period)(check_url) if throttle_period else check_url
-
         providers[provider] = {
             'url': attributes['url'],
             'auth': get_auth(attributes),
-            'checker': checker_function
+            'throttle': attributes.get('throttle', 0)
         }
 
     return providers
 
 
-def check_url(lock, file_name, dataset_uri, auth):
+def check_url(lock, file_name, dataset_uri, auth, throttle=0):
     """Sends an HTTP HEAD request to the URL and writes the URL to the
     output file if it fails
     """
-    response = requests.head(dataset_uri.uri, allow_redirects=True, auth=auth)
-    logging.debug("%d %s", response.status_code, dataset_uri.uri)
-    if response.status_code < 200 or response.status_code > 299:
-        with lock:
-            with open(file_name, 'a') as file_handle:
-                file_handle.write(
-                    f"{response.status_code} {dataset_uri.id} {dataset_uri.uri} {os.linesep}"
-                    f"{response.text} {os.linesep}{os.linesep}"
-                )
+    with closing(requests.head(dataset_uri.uri, allow_redirects=True, auth=auth)) as response:
+        logging.debug("%d %s", response.status_code, dataset_uri.uri)
+        if response.status_code < 200 or response.status_code > 299:
+            with lock:
+                with open(file_name, 'a') as file_handle:
+                    file_handle.write(
+                        f"{response.status_code} {dataset_uri.id} {dataset_uri.uri}{os.linesep}")
+    time.sleep(throttle)
 
 
-def check_provider_urls(file_name, checker, url_prefix, auth):
+def check_provider_urls(file_name, url_prefix, auth, throttle=0):
     """Check the URLs for one provider"""
     logging.info("Starting to check %s URLs", url_prefix)
     lock = Lock()
-    with concurrent.futures.ThreadPoolExecutor(max_workers=50) as thread_executor:
+    max_workers = 1 if throttle else 50
+    with BoundedThreadPoolExecutor(max_workers=max_workers, queue_limit=2000) as thread_executor:
         for dataset_uri in DatasetURI.objects.filter(uri__startswith=url_prefix).iterator():
-            thread_executor.submit(checker, lock, file_name, dataset_uri, auth)
+            thread_executor.submit(check_url, lock, file_name, dataset_uri, auth, throttle=throttle)
     logging.info("Finished checking %s URLs", url_prefix)
 
 
@@ -127,20 +128,32 @@ def main():
     providers = read_config(os.path.join(os.path.dirname(__file__), 'check.yml'))
 
     with concurrent.futures.ProcessPoolExecutor() as executor:
+        futures = {}
         for provider, attributes in providers.items():
             results_file_name = os.path.join(
                 dir_name,
                 f"{provider}_stale_urls_{datetime.now().strftime('%Y-%m-%dT%H:%M:%S')}.txt"
             )
-            executor.submit(
+            futures[executor.submit(
                 check_provider_urls,
                 results_file_name,
-                attributes['checker'],
                 attributes['url'],
-                attributes['auth']
-            )
+                attributes['auth'],
+                attributes['throttle']
+            )] = attributes['url']
 
-    logging.info("Finished checking all URLs")
+        error = False
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                future.result()
+            except Exception:
+                error = True
+                logging.error("An error occurred while checking '%s'",
+                              futures[future], exc_info=True)
+    if error:
+        sys.exit(1)
+    else:
+        logging.info("Finished checking all URLs")
 
 
 if __name__ == '__main__':

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -22,6 +22,7 @@ from geospaas.catalog.models import DatasetURI
 import geospaas_harvesting.utils as utils
 
 logger = logging.getLogger('geospaas_harvesting.verify_urls')
+logger.setLevel(logging.INFO)
 
 
 class TooManyRequests(Exception):

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -1,4 +1,26 @@
-"""URLs verification module"""
+"""URLs verification module
+Usage: verify_urls.py [-h] [-p PROVIDERS_CONF] {check,delete-stale} ...
+
+Check and cleanup dataset URIs.
+
+positional arguments:
+  {check,delete-stale}
+    check               Check all URIs present in the database. Write the
+                        stale URIs to files in the output directory (one file
+                        per provider).
+    delete-stale        Delete the stale URLs present in the file given as
+                        argument. The file should have the same structure as
+                        one obtained by running this script with the --check
+                        optionBy default, only URLs which return an HTTP error
+                        404 are deleted. To override this behaviour and remove
+                        URLs which return any kind of error, use the --force
+                        option.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PROVIDERS_CONF, --providers-conf PROVIDERS_CONF
+                        Path to the providers configuration file.
+"""
 import argparse
 import concurrent.futures
 import logging

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -44,7 +44,7 @@ class BoundedThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
         try:
             future = super().submit(fn, *args, **kwargs)
         except:
-            # if anything goes, wrong, we need to release the semaphore
+            # if anything goes wrong, we need to release the semaphore
             self.semaphore.release()
             raise
         else:

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -1,4 +1,5 @@
-""" Verification module. """
+"""URLs verification module"""
+import argparse
 import concurrent.futures
 import logging
 import os
@@ -19,7 +20,15 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'geospaas_harvesting.settings')
 django.setup()
 from geospaas.catalog.models import DatasetURI
 
-logging.basicConfig(level=logging.INFO)
+import geospaas_harvesting.utils as utils
+
+logger = logging.getLogger('geospaas_harvesting.verify_urls')
+
+
+class TooManyRequests(Exception):
+    """Exception raised when HTTP error 429 is repeatedly received from
+    a provider
+    """
 
 
 class BoundedThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
@@ -91,47 +100,69 @@ def read_config(config_path):
     return providers
 
 
-def check_url(lock, file_name, dataset_uri, auth, throttle=0):
-    """Sends an HTTP HEAD request to the URL and writes the URL to the
-    output file if it fails
+def check_url(dataset_uri, auth, throttle=0, tries=5):
+    """Sends an HTTP HEAD request to the URL and returns whether it is
+    valid or not
     """
-    with closing(requests.head(dataset_uri.uri, allow_redirects=True, auth=auth)) as response:
-        logging.debug("%d %s", response.status_code, dataset_uri.uri)
-        if response.status_code < 200 or response.status_code > 299:
-            with lock:
-                with open(file_name, 'a') as file_handle:
-                    file_handle.write(
-                        f"{response.status_code} {dataset_uri.id} {dataset_uri.uri}{os.linesep}")
+    while tries:
+        tries -= 1
+        with closing(utils.http_request(
+                'HEAD', dataset_uri.uri, allow_redirects=True, auth=auth)) as response:
+            status_code = response.status_code
+            headers = response.headers
+
+        logger.debug("%d %s", status_code, dataset_uri.uri)
+
+        # Too Many Requests: wait and retry
+        if status_code == 429:
+            if tries <= 0:
+                raise TooManyRequests(dataset_uri)
+            else:
+                logger.warning(
+                    "Error 429 received from '%s'; retries left: %d", dataset_uri, tries)
+                time.sleep(headers.get('Retry-After', 60))
+        # other errors: return False
+        elif status_code < 200 or status_code > 299:
+            tries = 0
+            is_valid = False
+        # no error: return True
+        else:
+            tries = 0
+            is_valid = True
+
     time.sleep(throttle)
+    return (is_valid, status_code, dataset_uri.id, dataset_uri.uri)
+
+
+def write_stale_url(lock, file_name, dataset_uri, auth, throttle=0, tries=5):
+    """Check the `dataset_uri` and write it to the output file if it is not valid"""
+    is_valid, status_code, dataset_uri_id, url = check_url(
+        dataset_uri, auth, throttle=throttle, tries=tries)
+
+    if not is_valid:
+        with lock, open(file_name, 'a') as file_handle:
+            file_handle.write(f"{status_code} {dataset_uri_id} {url}{os.linesep}")
 
 
 def check_provider_urls(file_name, url_prefix, auth, throttle=0):
     """Check the URLs for one provider"""
-    logging.info("Starting to check %s URLs", url_prefix)
+    logger.info("Starting to check %s URLs", url_prefix)
     lock = Lock()
     max_workers = 1 if throttle else 50
     with BoundedThreadPoolExecutor(max_workers=max_workers, queue_limit=2000) as thread_executor:
         for dataset_uri in DatasetURI.objects.filter(uri__startswith=url_prefix).iterator():
-            thread_executor.submit(check_url, lock, file_name, dataset_uri, auth, throttle=throttle)
-    logging.info("Finished checking %s URLs", url_prefix)
+            thread_executor.submit(
+                write_stale_url, lock, file_name, dataset_uri, auth, throttle=throttle)
+    logger.info("Finished checking %s URLs", url_prefix)
 
 
-def main():
-    """Runs one process per provider, which checks the URLs for this
-    provider
-    """
-    try:
-        dir_name = sys.argv[1]
-    except IndexError:
-        dir_name = '.'
-
-    providers = read_config(os.path.join(os.path.dirname(__file__), 'check.yml'))
-
+def check_providers(output_directory, providers):
+    """Check the URLs for each provider in a separate process"""
     with concurrent.futures.ProcessPoolExecutor() as executor:
         futures = {}
         for provider, attributes in providers.items():
             results_file_name = os.path.join(
-                dir_name,
+                output_directory,
                 f"{provider}_stale_urls_{datetime.now().strftime('%Y-%m-%dT%H:%M:%S')}.txt"
             )
             futures[executor.submit(
@@ -142,18 +173,108 @@ def main():
                 attributes['throttle']
             )] = attributes['url']
 
-        error = False
+        success = True
         for future in concurrent.futures.as_completed(futures):
             try:
                 future.result()
             except Exception:
-                error = True
-                logging.error("An error occurred while checking '%s'",
-                              futures[future], exc_info=True)
-    if error:
-        sys.exit(1)
-    else:
-        logging.info("Finished checking all URLs")
+                success = False
+                logger.error("An error occurred while checking '%s'",
+                             futures[future], exc_info=True)
+        return success
+
+
+def find_provider(url, providers):
+    """Find which provider a given URL comes from"""
+    for provider in providers.values():
+        if url.startswith(provider['url']):
+            return provider
+
+
+def remove_dataset_uri(dataset_uri):
+    """Remove a DatasetURI and the corresponding Dataset, if it has no
+    URIs anymore
+    """
+    logger.debug("Removing dataset URI %d, %s", dataset_uri.id, dataset_uri.uri)
+    dataset = dataset_uri.dataset
+    dataset_uri.delete()
+
+    remove_dataset = not dataset.dataseturi_set.all()  # .all() is needed to refresh the queryset
+    if remove_dataset:
+        logger.debug("Removing dataset %d", dataset.id)
+        dataset.delete()
+
+    return remove_dataset
+
+
+def delete_stale_urls(urls_file_path, providers, force=False):
+    """Re-check the URLs contained in a file issued from the checking
+    step, then remove them.
+    """
+    deleted_uris_count = 0
+    deleted_datasets_count = 0
+    with open(urls_file_path, 'r') as urls_file:
+        for line in urls_file:
+            _, dataset_uri_id, _ = line.split()
+            dataset_uri = DatasetURI.objects.get(id=dataset_uri_id)
+            provider = find_provider(dataset_uri.uri, providers)
+            is_valid, status_code, *_ = check_url(dataset_uri, provider['auth'])
+            if not is_valid and (status_code == 404 or force):
+                deleted_uris_count += 1
+                if remove_dataset_uri(dataset_uri):
+                    deleted_datasets_count += 1
+    return (deleted_uris_count, deleted_datasets_count)
+
+
+def parse_cli_arguments():
+    """Parse the arguments given on the command line"""
+    parser = argparse.ArgumentParser(description='Check and cleanup dataset URIs.')
+    parser.add_argument(
+        '-p', '--providers-conf',
+        default=os.path.join(os.path.dirname(__file__), 'check.yml'),
+        help='Path to the providers configuration file.')
+
+    sub_parsers = parser.add_subparsers(dest='action', required=True)
+
+    check_parser = sub_parsers.add_parser(
+        'check',
+        help=('Check all URIs present in the database. Write the stale URIs to files in the '
+              'output directory (one file per provider).'))
+    check_parser.add_argument(
+        '-o', '--output-directory',
+        default='.',
+        help='Path to the directory where the output files will be created')
+
+    delete_parser = sub_parsers.add_parser(
+        'delete-stale',
+        help=('Delete the stale URLs present in the file given as argument. The file should have '
+              'the same structure as one obtained by running this script with the --check option'
+              'By default, only URLs which return an HTTP error 404 are deleted. To override this '
+              'behaviour and remove URLs which return any kind of error, use the --force option.'))
+    delete_parser.add_argument(
+        'urls_file',
+        help='Path to the file containing the URls to delete.')
+    delete_parser.add_argument(
+        '-f', '--force',
+        action='store_true',
+        help='Remove URLs which return any error, not just 404')
+
+    return parser.parse_args()
+
+
+def main():
+    """Runs one process per provider, which checks the URLs for this
+    provider
+    """
+    args = parse_cli_arguments()
+    providers = read_config(args.providers_conf)
+
+    if args.action == 'check':
+        if check_providers(args.output_directory, providers):
+            logger.info("Finished checking all URLs")
+    elif args.action == 'delete-stale':
+        deleted_counts = delete_stale_urls(args.urls_file, providers)
+        logger.info("Deleted %d URIs and %d datasets", *deleted_counts)
 
 
 if __name__ == '__main__':

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -1,29 +1,68 @@
 """ Verification module. """
+from geospaas.catalog.models import DatasetURI
+import concurrent.futures
+import logging
 import os
 import sys
 from datetime import datetime
+from threading import Lock
 
 import django
 import requests
+import requests.auth
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'geospaas_harvesting.settings')
 django.setup()
 
-from geospaas.catalog.models import DatasetURI
+
+logging.basicConfig(level=logging.INFO)
+
+providers = {
+    'scihub': (
+        'https://scihub.copernicus.eu',
+        requests.auth.HTTPBasicAuth('topvoys', os.environ.get('COPERNICUS_OPEN_HUB_PASSWORD'))
+    ),
+    'podaac': ('https://opendap.jpl.nasa.gov/opendap/', None)
+}
+
+
+def check_url(lock, file_name, dataset_uri, auth):
+    """"""
+    response = requests.head(dataset_uri.uri, allow_redirects=True, auth=auth)
+    logging.debug("%d %s", response.status_code, dataset_uri.uri)
+    if response.status_code < 200 or response.status_code > 299:
+        with lock:
+            with open(file_name, 'w') as file_handle:
+                file_handle.write(f"{response.status_code} {dataset_uri.uri} {os.linesep}")
+
+
+def check_provider_urls(file_name, url_prefix, auth):
+    """"""
+    logging.info("Starting to check %s URLs", url_prefix)
+    lock = Lock()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=50) as thread_executor:
+        # with open(file_name, 'w') as file_handle:
+        for dataset_uri in DatasetURI.objects.filter(uri__startswith=url_prefix).iterator():
+            thread_executor.submit(check_url, lock, file_name, dataset_uri, auth)
+    logging.info("Finished checking %s URLs", url_prefix)
+
 
 def main():
-    """ Verifies the datasets based on their dataseturi. If the download link does not provide a
-    download availability and returns a response that does not start with '2' in its status code,
-    then the dataset uri is written into a file named "filename"."""
+    """"""
     try:
-        filename = sys.argv[1]
+        dir_name = sys.argv[1]
     except IndexError:
-        filename = f"unverified_datasets_at_{datetime.now().strftime('%Y-%m-%d___%H_%M_%S')}"
-    with open(filename + ".txt", 'w') as f:
-        for dsuri in DatasetURI.objects.iterator():
-            response = requests.head(dsuri.uri, allow_redirects=True)
-            if response.status_code < 200 or response.status_code > 299:
-                f.write(dsuri.uri + os.linesep)
+        dir_name = '.'
+
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        for file_prefix, (url_prefix, auth) in providers.items():
+            file_name = os.path.join(
+                dir_name,
+                f"{file_prefix}_stale_urls_{datetime.now().strftime('%Y-%m-%dT%H:%M:%S')}.txt"
+            )
+            executor.submit(check_provider_urls, file_name, url_prefix, auth)
+
+    logging.info("Finished checking all URLs")
 
 
 if __name__ == '__main__':

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -190,6 +190,7 @@ def find_provider(url, providers):
     for provider in providers.values():
         if url.startswith(provider['url']):
             return provider
+    return None
 
 
 def remove_dataset_uri(dataset_uri):
@@ -217,7 +218,7 @@ def delete_stale_urls(urls_file_path, providers, force=False):
     with open(urls_file_path, 'r') as urls_file:
         for line in urls_file:
             _, dataset_uri_id, _ = line.split()
-            dataset_uri = DatasetURI.objects.get(id=dataset_uri_id)
+            dataset_uri = DatasetURI.objects.get(id=int(dataset_uri_id))
             provider = find_provider(dataset_uri.uri, providers)
             is_valid, status_code, *_ = check_url(dataset_uri, provider['auth'])
             if not is_valid and (status_code == 404 or force):

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -1,66 +1,144 @@
 """ Verification module. """
-from geospaas.catalog.models import DatasetURI
 import concurrent.futures
+import functools
 import logging
 import os
 import sys
+import time
 from datetime import datetime
 from threading import Lock
 
 import django
+import oauthlib.oauth2
 import requests
 import requests.auth
+import requests_oauthlib
+import yaml
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'geospaas_harvesting.settings')
 django.setup()
+from geospaas.catalog.models import DatasetURI
 
 
 logging.basicConfig(level=logging.INFO)
 
-providers = {
-    'scihub': (
-        'https://scihub.copernicus.eu',
-        requests.auth.HTTPBasicAuth('topvoys', os.environ.get('COPERNICUS_OPEN_HUB_PASSWORD'))
-    ),
-    'podaac': ('https://opendap.jpl.nasa.gov/opendap/', None)
-}
+
+def throttle(period):
+    """Decorator builder. Returns a decorator which prevents a function
+    from being called more than once every `period` seconds
+    """
+    def decorator_throttle(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if wrapper.last_call:
+                time_since_last_call = time.monotonic() - wrapper.last_call
+                if time_since_last_call < period:
+                    time.sleep(period - time_since_last_call)
+            wrapper.last_call = time.monotonic()
+            return func(*args, **kwargs)
+        wrapper.last_call = 0
+        return wrapper
+    return decorator_throttle
+
+
+def build_oauth2(username, password, token_url, client_id):
+    """Creates an OAuth2 object usable by requests.get()"""
+    client = oauthlib.oauth2.LegacyApplicationClient(client_id=client_id)
+    token = requests_oauthlib.OAuth2Session(client=client).fetch_token(
+        token_url=token_url,
+        username=username,
+        password=password,
+        client_id=client_id,
+    )
+    return requests_oauthlib.OAuth2(client_id=client_id, client=client, token=token)
+
+
+def get_auth(attributes):
+    """Returns the right authentication object based on the provided
+    attributes
+    """
+    if set(('username', 'password', 'token_url', 'client_id')).issubset(attributes):
+        return build_oauth2(
+            attributes['username'], attributes['password'],
+            attributes['token_url'], attributes['client_id'],
+        )
+    elif set(('username', 'password')).issubset(attributes):
+        return requests.auth.HTTPBasicAuth(attributes['username'], attributes['password'])
+    else:
+        return None
+
+
+def read_config(config_path):
+    """Reads the configuration file and build a providers dictionary
+    """
+    yaml.SafeLoader.add_constructor('!ENV', lambda loader, node: os.getenv(node.value))
+    with open(config_path, 'r') as config_file:
+        config = yaml.safe_load(config_file)
+
+    providers = {}
+    for provider, attributes in config.items():
+
+        throttle_period = attributes.get('throttle')
+        checker_function = throttle(throttle_period)(check_url) if throttle_period else check_url
+
+        providers[provider] = {
+            'url': attributes['url'],
+            'auth': get_auth(attributes),
+            'checker': checker_function
+        }
+
+    return providers
 
 
 def check_url(lock, file_name, dataset_uri, auth):
-    """"""
+    """Sends an HTTP HEAD request to the URL and writes the URL to the
+    output file if it fails
+    """
     response = requests.head(dataset_uri.uri, allow_redirects=True, auth=auth)
     logging.debug("%d %s", response.status_code, dataset_uri.uri)
     if response.status_code < 200 or response.status_code > 299:
         with lock:
-            with open(file_name, 'w') as file_handle:
-                file_handle.write(f"{response.status_code} {dataset_uri.uri} {os.linesep}")
+            with open(file_name, 'a') as file_handle:
+                file_handle.write(
+                    f"{response.status_code} {dataset_uri.id} {dataset_uri.uri} {os.linesep}"
+                    f"{response.text} {os.linesep}{os.linesep}"
+                )
 
 
-def check_provider_urls(file_name, url_prefix, auth):
-    """"""
+def check_provider_urls(file_name, checker, url_prefix, auth):
+    """Check the URLs for one provider"""
     logging.info("Starting to check %s URLs", url_prefix)
     lock = Lock()
     with concurrent.futures.ThreadPoolExecutor(max_workers=50) as thread_executor:
-        # with open(file_name, 'w') as file_handle:
         for dataset_uri in DatasetURI.objects.filter(uri__startswith=url_prefix).iterator():
-            thread_executor.submit(check_url, lock, file_name, dataset_uri, auth)
+            thread_executor.submit(checker, lock, file_name, dataset_uri, auth)
     logging.info("Finished checking %s URLs", url_prefix)
 
 
 def main():
-    """"""
+    """Runs one process per provider, which checks the URLs for this
+    provider
+    """
     try:
         dir_name = sys.argv[1]
     except IndexError:
         dir_name = '.'
 
+    providers = read_config(os.path.join(os.path.dirname(__file__), 'check.yml'))
+
     with concurrent.futures.ProcessPoolExecutor() as executor:
-        for file_prefix, (url_prefix, auth) in providers.items():
-            file_name = os.path.join(
+        for provider, attributes in providers.items():
+            results_file_name = os.path.join(
                 dir_name,
-                f"{file_prefix}_stale_urls_{datetime.now().strftime('%Y-%m-%dT%H:%M:%S')}.txt"
+                f"{provider}_stale_urls_{datetime.now().strftime('%Y-%m-%dT%H:%M:%S')}.txt"
             )
-            executor.submit(check_provider_urls, file_name, url_prefix, auth)
+            executor.submit(
+                check_provider_urls,
+                results_file_name,
+                attributes['checker'],
+                attributes['url'],
+                attributes['auth']
+            )
 
     logging.info("Finished checking all URLs")
 

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -3,7 +3,6 @@ import argparse
 import concurrent.futures
 import logging
 import os
-import sys
 import time
 from contextlib import closing
 from datetime import datetime

--- a/geospaas_harvesting/verify_urls.py
+++ b/geospaas_harvesting/verify_urls.py
@@ -134,7 +134,9 @@ def check_url(dataset_uri, auth, throttle=0, tries=5):
 
 
 def write_stale_url(lock, file_name, dataset_uri, auth, throttle=0, tries=5):
-    """Check the `dataset_uri` and write it to the output file if it is not valid"""
+    """Check the `dataset_uri` and write it to the output file if it is
+    not valid. This is the function that runs in the checking threads.
+    """
     is_valid, status_code, dataset_uri_id, url = check_url(
         dataset_uri, auth, throttle=throttle, tries=tries)
 

--- a/tests/test_verify_urls.py
+++ b/tests/test_verify_urls.py
@@ -1,46 +1,539 @@
 """ Test the verification code """
+import argparse
+import io
+import logging
 import os
-import tempfile
+import os.path
+import textwrap
+import unittest
 import unittest.mock as mock
 
-import django
-from geospaas_harvesting import verify_urls
+import requests.auth
+import requests_oauthlib
 
-from tests.test_ingesters import IngesterTestCase
+import geospaas_harvesting.verify_urls as verify_urls
 
 
-class VerifierTestCase(django.test.TransactionTestCase):
-    """ Test the verification code """
+class VerifyURLsTestCase(unittest.TestCase):
+    """Test the URLs verification module"""
 
-    @mock.patch('requests.head')
-    def test_download_link_responded_correctly(self, mock_request):
-        """Shall not write dataset to file from database because of healthy download link"""
-        mock_request.return_value.status_code = 200
-        dataset, _ = IngesterTestCase._create_dummy_dataset(IngesterTestCase, 'test')
-        IngesterTestCase._create_dummy_dataset_uri(
-            IngesterTestCase, 'http://test.uri/dataset', dataset)
-        IngesterTestCase._create_dummy_dataset_uri(
-            IngesterTestCase, 'http://anotherhost/dataset', dataset)
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            os.chdir(tmpdirname)
-            verify_urls.main()
-            file_content = open(os.listdir()[0], "r").read()
-            self.assertEqual('', file_content)
-        os.chdir('..')
+    def test_main_check(self):
+        """The correct actions should be launched depending on the CLI
+        arguments
+        """
+        args = mock.Mock()
+        args.action = 'check'
+        with mock.patch('geospaas_harvesting.verify_urls.parse_cli_arguments', return_value=args), \
+                mock.patch('geospaas_harvesting.verify_urls.read_config'), \
+                mock.patch('geospaas_harvesting.verify_urls.check_providers') as mock_check, \
+                mock.patch('geospaas_harvesting.verify_urls.delete_stale_urls') as mock_delete:
 
-    @mock.patch('requests.head')
-    def test_download_link_responded_with_incorrect_status_code(self, mock_request):
-        """Shall write dataset to file from database because of unhealthy download link"""
-        mock_request.return_value.status_code = 504
-        dataset, _ = IngesterTestCase._create_dummy_dataset(IngesterTestCase, 'test')
-        IngesterTestCase._create_dummy_dataset_uri(
-            IngesterTestCase, 'http://test.uri/dataset', dataset)
-        IngesterTestCase._create_dummy_dataset_uri(
-            IngesterTestCase, 'http://anotherhost/dataset', dataset)
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            os.chdir(tmpdirname)
-            verify_urls.main()
-            file_content = open(os.listdir()[0], "r").read()
-            self.assertIn('http://test.uri/dataset', file_content)
-            self.assertIn('http://anotherhost/dataset', file_content)
-        os.chdir('..')
+            with self.assertLogs(verify_urls.logger):
+                verify_urls.main()
+            mock_check.assert_called_once()
+            mock_delete.assert_not_called()
+
+    def test_main_delete(self):
+        args = mock.Mock()
+        args.action = 'delete-stale'
+        with mock.patch('geospaas_harvesting.verify_urls.parse_cli_arguments', return_value=args), \
+                mock.patch('geospaas_harvesting.verify_urls.read_config'), \
+                mock.patch('geospaas_harvesting.verify_urls.check_providers') as mock_check, \
+                mock.patch('geospaas_harvesting.verify_urls.delete_stale_urls') as mock_delete:
+
+            with self.assertLogs(verify_urls.logger):
+                verify_urls.main()
+            mock_check.assert_not_called()
+            mock_delete.assert_called_once()
+
+    def test_parse_cli_arguments_check(self):
+        """Test CLI arguments parsing for the check action"""
+        with mock.patch('sys.argv',
+                        ['verify_urls.py', '-p', '/foo.yml', 'check', '-o', '/bar']):
+            self.assertEqual(
+                verify_urls.parse_cli_arguments(),
+                argparse.Namespace(
+                    providers_conf='/foo.yml', action='check', output_directory='/bar'))
+
+    def test_parse_cli_arguments_check_defaults(self):
+        """Test CLI arguments parsing for the check action with default
+        values
+        """
+        default_provider_conf = os.path.join(os.path.dirname(verify_urls.__file__), 'check.yml')
+        with mock.patch('sys.argv', ['verify_urls.py', 'check']):
+            self.assertEqual(
+                verify_urls.parse_cli_arguments(),
+                argparse.Namespace(
+                    providers_conf=default_provider_conf, action='check', output_directory='.'))
+
+    def test_parse_cli_arguments_delete(self):
+        """Test CLI arguments parsing for the delete action"""
+        with mock.patch('sys.argv',
+                        ['verify_urls.py', '-p', '/foo.yml', 'delete-stale', '/bar/baz.txt']):
+            self.assertEqual(
+                verify_urls.parse_cli_arguments(),
+                argparse.Namespace(
+                    providers_conf='/foo.yml',
+                    action='delete-stale',
+                    urls_file='/bar/baz.txt',
+                    force=False))
+
+    def test_parse_cli_arguments_delete_force(self):
+        """Test CLI arguments parsing for the delete action with the force option"""
+        with mock.patch('sys.argv',
+                        ['verify_urls.py', '-p', '/foo.yml', 'delete-stale', '/bar/baz.txt', '-f']):
+            self.assertEqual(
+                verify_urls.parse_cli_arguments(),
+                argparse.Namespace(
+                    providers_conf='/foo.yml',
+                    action='delete-stale',
+                    urls_file='/bar/baz.txt',
+                    force=True))
+
+    def test_parse_cli_arguments_no_action(self):
+        """An error should be raised if no action is specified in the
+        CLI arguments
+        """
+        buffer = io.StringIO()
+        with mock.patch('sys.argv', ['verify_urls.py']), \
+                mock.patch('sys.stderr', buffer), \
+                self.assertRaises(SystemExit):
+            verify_urls.parse_cli_arguments()
+            self.assertIn(
+                'the following arguments are required: action',
+                buffer.getvalue())
+
+    def test_parse_cli_arguments_check_wrong_arg(self):
+        """An error should be raised if the wrong argument is provided
+        to the check action
+        """
+        buffer = io.StringIO()
+        with mock.patch('sys.argv', ['verify_urls.py', 'check', '-f']), \
+                mock.patch('sys.stderr', buffer), \
+                self.assertRaises(SystemExit):
+            verify_urls.parse_cli_arguments()
+            self.assertIn('unrecognized arguments: -f', buffer.getvalue())
+
+    def test_parse_cli_arguments_delete_wrong_arg(self):
+        """An error should be raised if the wrong argument is provided
+        to the delete action
+        """
+        buffer = io.StringIO()
+        with mock.patch('sys.argv', ['verify_urls.py', 'delete-stale', '-o', '/bar']), \
+                mock.patch('sys.stderr', buffer), \
+                self.assertRaises(SystemExit):
+            verify_urls.parse_cli_arguments()
+            self.assertIn('unrecognized arguments: -o', buffer.getvalue())
+
+    def test_delete_stale_urls(self):
+        """404 URLs should be deleted unless the force option is used
+        """
+        provider = {'url': 'https://foo', 'auth': ('username', 'password')}
+        file_contents = '404 12 https://foo/bar\n500 13 https://foo/baz'
+        check_url_results = (
+            (False, 404, 12, 'https://foo/bar'),
+            (False, 500, 13, 'https://foo/baz')
+        )
+
+        dataset_uris = {12: 'https://foo/bar', 13: 'https://foo/baz'}
+        mock_manager = mock.Mock()
+        mock_manager.get.side_effect = lambda id: mock.Mock(uri=dataset_uris[id])
+
+        with mock.patch('geospaas_harvesting.verify_urls.find_provider', return_value=provider), \
+             mock.patch('geospaas_harvesting.verify_urls.DatasetURI.objects', mock_manager):
+
+            buffer = io.StringIO(file_contents)
+            with mock.patch('geospaas_harvesting.verify_urls.open', return_value=buffer), \
+                    mock.patch('geospaas_harvesting.verify_urls.check_url',
+                                side_effect=check_url_results), \
+                    mock.patch('geospaas_harvesting.verify_urls.remove_dataset_uri',
+                                return_value=True) as mock_remove:
+                # force == False, only the URL that returns 404 must be
+                # deleted
+                self.assertEqual(verify_urls.delete_stale_urls('', {}, force=False), (1, 1))
+                self.assertListEqual(
+                    [args[0][0].uri for args in mock_remove.call_args_list],
+                    ['https://foo/bar'])
+
+            buffer = io.StringIO(file_contents)
+            with mock.patch('geospaas_harvesting.verify_urls.open', return_value=buffer), \
+                    mock.patch('geospaas_harvesting.verify_urls.check_url',
+                                side_effect=check_url_results), \
+                    mock.patch('geospaas_harvesting.verify_urls.remove_dataset_uri',
+                            return_value=True) as mock_remove:
+                # force == True, both URLs must be deleted
+                self.assertEqual(verify_urls.delete_stale_urls('', {}, force=True), (2, 2))
+                self.assertListEqual(
+                    [args[0][0].uri for args in mock_remove.call_args_list],
+                    ['https://foo/bar', 'https://foo/baz'])
+
+    def test_remove_dataset_uri(self):
+        """The URI should be removed, as well as the corresponding
+        dataset if it does not have anymore URIs
+        """
+        dataset_uri = mock.Mock()
+
+        # simulate empty queryset
+        dataset_uri.dataset.dataseturi_set.all.return_value = []
+        self.assertTrue(verify_urls.remove_dataset_uri(dataset_uri))
+        dataset_uri.delete.assert_called_once_with()
+        dataset_uri.dataset.delete.assert_called_once_with()
+
+        dataset_uri.reset_mock()
+
+        # simulate queryset with one element
+        dataset_uri.dataset.dataseturi_set.all.return_value = [mock.Mock()]
+        self.assertFalse(verify_urls.remove_dataset_uri(dataset_uri))
+        dataset_uri.delete.assert_called_once_with()
+        dataset_uri.dataset.delete.assert_not_called()
+
+    def test_find_provider(self):
+        """Should return the right provider given a URL"""
+        scihub_attributes = {
+            'url': 'https://scihub.copernicus.eu/',
+            'auth': ('scihub_user', 'scihub_pass'),
+            'throttle': 0
+        }
+        podaac_attributes = {
+            'url': 'https://opendap.jpl.nasa.gov/opendap/',
+            'auth': ('podaac_user', 'podaac_pass'),
+            'throttle': 0
+        }
+
+        providers = {
+            'scihub': scihub_attributes,
+            'podaac': podaac_attributes
+        }
+        self.assertIsNone(verify_urls.find_provider('https://foo', providers))
+        self.assertDictEqual(
+            verify_urls.find_provider('https://scihub.copernicus.eu/foo', providers),
+            scihub_attributes)
+        self.assertDictEqual(
+            verify_urls.find_provider('https://opendap.jpl.nasa.gov/opendap/foo', providers),
+            podaac_attributes)
+
+    def test_check_providers(self):
+        """Should run URL checks for each provider in a separate
+        process. If an exception is raised in one of the sub-processes,
+        check_providers() should return False and the traceback of the
+        exception should be logged
+        """
+        scihub_attributes = {
+            'url': 'https://scihub.copernicus.eu/',
+            'auth': ('scihub_user', 'scihub_pass'),
+            'throttle': 0
+        }
+        podaac_attributes = {
+            'url': 'https://opendap.jpl.nasa.gov/opendap/',
+            'auth': ('podaac_user', 'podaac_pass'),
+            'throttle': 0
+        }
+
+        providers = {
+            'scihub': scihub_attributes,
+            'podaac': podaac_attributes
+        }
+
+        with mock.patch('concurrent.futures.ProcessPoolExecutor') as mock_pool, \
+                mock.patch('geospaas_harvesting.verify_urls.datetime') as mock_datetime, \
+                mock.patch('geospaas_harvesting.verify_urls.check_provider_urls') as mock_check, \
+                mock.patch('concurrent.futures.as_completed', iter):
+            mock_executor = mock_pool.return_value.__enter__.return_value
+            mock_datetime.now.return_value.strftime.return_value = 'time'
+            self.assertTrue(verify_urls.check_providers('foo', providers))
+            mock_executor.submit.assert_has_calls((
+                mock.call(
+                    mock_check,
+                    os.path.join('foo', 'scihub_stale_urls_time.txt'),
+                    scihub_attributes['url'],
+                    scihub_attributes['auth'],
+                    scihub_attributes['throttle']),
+                mock.call(
+                    mock_check,
+                    os.path.join('foo', 'podaac_stale_urls_time.txt'),
+                    podaac_attributes['url'],
+                    podaac_attributes['auth'],
+                    podaac_attributes['throttle'])
+            ), any_order=True)
+            self.assertEqual(len(mock_executor.submit.call_args_list), 2)
+
+            mock_executor.submit.return_value.result.side_effect = AttributeError
+            with self.assertLogs(verify_urls.logger, level=logging.ERROR):
+                self.assertFalse(verify_urls.check_providers('foo', providers))
+
+    def test_check_provider_urls(self):
+        """Should check all the URLs for one provider"""
+        mock_lock = mock.Mock()
+        with mock.patch('geospaas_harvesting.verify_urls.Lock', return_value=mock_lock), \
+                mock.patch(
+                    'geospaas_harvesting.verify_urls.BoundedThreadPoolExecutor') as mock_pool, \
+                mock.patch('geospaas_harvesting.verify_urls.DatasetURI.objects') as mock_manager, \
+                mock.patch('geospaas_harvesting.verify_urls.write_stale_url') as mock_write:
+            mock_executor = mock_pool.return_value.__enter__.return_value
+            mock_dataset_uri = mock.Mock()
+            mock_auth = mock.Mock()
+            mock_manager.filter.return_value.iterator.return_value = [mock_dataset_uri]
+
+            # call without throttle: 50 workers
+            with self.assertLogs(verify_urls.logger, level=logging.INFO):
+                verify_urls.check_provider_urls('output.txt', 'https://foo/', mock_auth)
+
+            mock_executor.submit.assert_called_once_with(
+                mock_write, mock_lock, 'output.txt', mock_dataset_uri, mock_auth, throttle=0)
+            mock_pool.assert_called_once_with(max_workers=50, queue_limit=2000)
+
+            mock_pool.reset_mock()
+
+            # call with throttle: 1 worker
+            with self.assertLogs(verify_urls.logger, level=logging.INFO):
+                verify_urls.check_provider_urls('output.txt', 'https://foo/', mock_auth, throttle=1)
+            mock_executor.submit.assert_called_once_with(
+                mock_write, mock_lock, 'output.txt', mock_dataset_uri, mock_auth, throttle=1)
+            mock_pool.assert_called_once_with(max_workers=1, queue_limit=2000)
+
+    def test_write_stale_url_valid(self):
+        """Should not write anything to the output file if the URL is
+        valid
+        """
+        mock_lock = mock.MagicMock()
+        with mock.patch('geospaas_harvesting.verify_urls.check_url',
+                        return_value=(True, 200, 1, 'https://foo')), \
+                 mock.patch('geospaas_harvesting.verify_urls.open') as mock_open:
+            verify_urls.write_stale_url(mock_lock, 'output.txt', mock.Mock(), mock.Mock())
+            mock_open.assert_not_called()
+
+    def test_write_stale_url_invalid(self):
+        """Should write the URL info to the output file if the URL is
+        invalid
+        """
+        with mock.patch('geospaas_harvesting.verify_urls.check_url',
+                        return_value=(False, 404, 1, 'https://foo')), \
+                mock.patch('geospaas_harvesting.verify_urls.open') as mock_open:
+            mock_file = mock.MagicMock()
+            mock_open.return_value.__enter__.return_value = mock_file
+            verify_urls.write_stale_url(mock.MagicMock(), 'output.txt', mock.Mock(), mock.Mock())
+            mock_file.write.assert_called_once_with(f"404 1 https://foo{os.linesep}")
+
+    def test_check_url_200(self):
+        """Should send a HEAD request to the URL and return whether the
+        URL is valid or not.
+        """
+        mock_dataset_uri = mock.Mock(id=1, uri='https://foo')
+        mock_response = mock.MagicMock(status_code=200, headers={})
+        with mock.patch('geospaas_harvesting.utils.http_request',
+                        return_value=mock_response) as mock_request:
+            self.assertTupleEqual(
+                verify_urls.check_url(mock_dataset_uri, mock.Mock()),
+                (True, 200, 1, 'https://foo')
+            )
+
+    def test_check_url_404(self):
+        """Should send a HEAD request to the URL and return whether the
+        URL is valid or not.
+        """
+        mock_dataset_uri = mock.Mock(id=1, uri='https://foo')
+        mock_response = mock.MagicMock(status_code=404, headers={})
+        with mock.patch('geospaas_harvesting.utils.http_request',
+                        return_value=mock_response) as mock_request:
+            self.assertTupleEqual(
+                verify_urls.check_url(mock_dataset_uri, mock.Mock()),
+                (False, 404, 1, 'https://foo'))
+            mock_request.assert_called_once()
+
+    def test_check_url_429_no_header(self):
+        """When an error 429 occurs, the URL should ne retried after a
+        delay
+        """
+        mock_dataset_uri = mock.Mock(id=1, uri='https://foo')
+        mock_responses = (
+            mock.MagicMock(status_code=429, headers={}),
+            mock.MagicMock(status_code=404, headers={})
+        )
+        with mock.patch('geospaas_harvesting.utils.http_request',
+                        side_effect=mock_responses) as mock_request, \
+                mock.patch('time.sleep') as mock_sleep:
+
+            with self.assertLogs(verify_urls.logger, level=logging.WARNING):
+                self.assertTupleEqual(
+                    verify_urls.check_url(mock_dataset_uri, mock.Mock()),
+                    (False, 404, 1, 'https://foo'))
+
+            self.assertEqual(mock_request.call_count, 2)
+            mock_sleep.assert_has_calls((mock.call(60), mock.call(0)))
+
+    def test_check_url_429_retry_after_header(self):
+        """When an error 429 occurs, the URL should ne retried after a
+        delay
+        """
+        mock_dataset_uri = mock.Mock(id=1, uri='https://foo')
+        mock_responses = (
+            mock.MagicMock(status_code=429, headers={'Retry-After': 2}),
+            mock.MagicMock(status_code=200, headers={})
+        )
+        with mock.patch('geospaas_harvesting.utils.http_request',
+                        side_effect=mock_responses) as mock_request, \
+                mock.patch('time.sleep') as mock_sleep:
+
+            with self.assertLogs(verify_urls.logger, level=logging.WARNING):
+                self.assertTupleEqual(
+                    verify_urls.check_url(mock_dataset_uri, mock.Mock(), throttle=1),
+                    (True, 200, 1, 'https://foo'))
+
+            self.assertEqual(mock_request.call_count, 2)
+            mock_sleep.assert_has_calls((mock.call(2), mock.call(1)))
+
+    def test_check_url_429_too_many_retries(self):
+        """When there are too many retries, an exception should be
+        raised
+        """
+        mock_dataset_uri = mock.Mock(id=1, uri='https://foo')
+        mock_responses = (
+            mock.MagicMock(status_code=429, headers={}),
+            mock.MagicMock(status_code=200, headers={})
+        )
+        with mock.patch('geospaas_harvesting.utils.http_request',
+                        side_effect=mock_responses) as mock_request:
+
+            with self.assertRaises(verify_urls.TooManyRequests):
+                verify_urls.check_url(mock_dataset_uri, mock.Mock(), tries=1)
+            mock_request.assert_called_once()
+
+    def test_read_config(self):
+        """Should read the provider configuration from a YAML file"""
+        config = textwrap.dedent('''---
+        podaac:
+          url: 'https://opendap.jpl.nasa.gov/opendap/'
+        scihub:
+          url: 'https://scihub.copernicus.eu/'
+          username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
+          password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
+        creodias:
+          url: 'https://zipper.creodias.eu/'
+          username: !ENV 'CREODIAS_USERNAME'
+          password: !ENV 'CREODIAS_PASSWORD'
+          token_url: 'https://auth.creodias.eu/auth/realms/DIAS/protocol/openid-connect/token'
+          client_id: 'CLOUDFERRO_PUBLIC'
+          throttle: 1
+          ''')
+        environment = {
+            'COPERNICUS_OPEN_HUB_USERNAME': 'copernicus_user',
+            'COPERNICUS_OPEN_HUB_PASSWORD': 'copernicus_password',
+            'CREODIAS_USERNAME': 'creodias_user',
+            'CREODIAS_PASSWORD': 'creodias_password',
+        }
+        # we check that get_auth() is called with the right arguments
+        # by replacing its output by its arguments
+        with mock.patch('geospaas_harvesting.verify_urls.open', mock.mock_open(read_data=config)), \
+                mock.patch('geospaas_harvesting.verify_urls.get_auth',
+                           side_effect=lambda args: args), \
+                mock.patch('os.environ', environment):
+            providers = verify_urls.read_config('foo.yml')
+
+        self.assertDictEqual(providers, {
+            'podaac': {
+                'url': 'https://opendap.jpl.nasa.gov/opendap/',
+                'auth': {'url': 'https://opendap.jpl.nasa.gov/opendap/'},
+                'throttle': 0
+            },
+            'scihub': {
+                'url': 'https://scihub.copernicus.eu/',
+                'auth': {
+                    'url': 'https://scihub.copernicus.eu/',
+                    'username': 'copernicus_user',
+                    'password': 'copernicus_password'
+                },
+                'throttle': 0
+            },
+            'creodias': {
+                'url': 'https://zipper.creodias.eu/',
+                'auth': {
+                    'url': 'https://zipper.creodias.eu/',
+                    'username': 'creodias_user',
+                    'password': 'creodias_password',
+                    'token_url': 'https://auth.creodias.eu/auth/realms/DIAS/protocol/'
+                                 'openid-connect/token',
+                    'client_id': 'CLOUDFERRO_PUBLIC',
+                    'throttle': 1
+                },
+                'throttle': 1
+            },
+        })
+
+    def test_get_auth_oauth2(self):
+        """Should return the right authentication object based on the
+        provider attributes
+        """
+        # oauth2
+        mock_oauth2 = mock.Mock()
+        with mock.patch('geospaas_harvesting.verify_urls.build_oauth2',
+                        return_value=mock_oauth2) as mock_build_oauth2:
+            self.assertEqual(
+                verify_urls.get_auth({
+                    'username': 'user',
+                    'password': 'pass',
+                    'token_url': 'https://foo',
+                    'client_id': 'CLIENT'
+                }),
+                mock_oauth2)
+            mock_build_oauth2.assert_called_once_with('user', 'pass', 'https://foo', 'CLIENT')
+
+    def test_get_auth_basic(self):
+        """Should return the right authentication object based on the
+        provider attributes
+        """
+        # basic HTTP auth
+        self.assertEqual(
+            verify_urls.get_auth({'username': 'user', 'password': 'pass'}),
+            requests.auth.HTTPBasicAuth('user', 'pass'))
+
+    def test_get_auth_no_auth(self):
+        """Should return the right authentication object based on the
+        provider attributes
+        """
+        # no authentication
+        self.assertIsNone(verify_urls.get_auth({}))
+
+    def test_build_oauth2(self):
+        """Should return an OAuth2 object usable by `requests`"""
+        with mock.patch('requests_oauthlib.OAuth2Session') as mock_oauth2_session:
+            self.assertIsInstance(
+                verify_urls.build_oauth2('user', 'pass', 'https://foo', 'CLIENT'),
+                requests_oauthlib.OAuth2)
+            mock_oauth2_session.return_value.fetch_token.assert_called_with(
+                token_url='https://foo',
+                username='user',
+                password='pass',
+                client_id='CLIENT'
+            )
+
+    def test_bounded_thread_pool_executor_init(self):
+        """The executor should have a semaphore attribute with an
+        initial value equal to the provided queue limit + the number of
+        workers
+        """
+        pool_executor = verify_urls.BoundedThreadPoolExecutor(max_workers=1, queue_limit=1)
+        self.assertIsInstance(pool_executor.semaphore, verify_urls.BoundedSemaphore)
+        self.assertEqual(pool_executor.semaphore._initial_value, 2)
+
+    def test_bounded_thread_pool_executor_submit(self):
+        """This executor should stop adding jobs to its internal queue
+        when it hits the limit
+        """
+        # check that the semaphore is acquired and released in a
+        # normal case
+        with verify_urls.BoundedThreadPoolExecutor(max_workers=1, queue_limit=1) as bounded_pool:
+            bounded_pool.semaphore = mock.Mock()
+            bounded_pool.submit(lambda x: x, 1,)
+        bounded_pool.semaphore.acquire.assert_called()
+        bounded_pool.semaphore.release.assert_called()
+
+        # check that the semaphore is acquired and released when
+        # submit() raises an exception
+        with mock.patch('concurrent.futures.ThreadPoolExecutor.submit', side_effect=ValueError):
+            with verify_urls.BoundedThreadPoolExecutor(
+                    max_workers=1, queue_limit=1) as bounded_pool:
+                bounded_pool.semaphore = mock.Mock()
+                with self.assertRaises(ValueError):
+                    bounded_pool.submit(lambda x: x, 1,)
+        bounded_pool.semaphore.acquire.assert_called()
+        bounded_pool.semaphore.release.assert_called()

--- a/tests/test_verify_urls.py
+++ b/tests/test_verify_urls.py
@@ -333,12 +333,10 @@ class VerifyURLsTestCase(unittest.TestCase):
         """
         mock_dataset_uri = mock.Mock(id=1, uri='https://foo')
         mock_response = mock.MagicMock(status_code=200, headers={})
-        with mock.patch('geospaas_harvesting.utils.http_request',
-                        return_value=mock_response) as mock_request:
+        with mock.patch('geospaas_harvesting.utils.http_request', return_value=mock_response):
             self.assertTupleEqual(
                 verify_urls.check_url(mock_dataset_uri, mock.Mock()),
-                (True, 200, 1, 'https://foo')
-            )
+                (True, 200, 1, 'https://foo'))
 
     def test_check_url_404(self):
         """Should send a HEAD request to the URL and return whether the

--- a/tests/test_verify_urls.py
+++ b/tests/test_verify_urls.py
@@ -409,6 +409,20 @@ class VerifyURLsTestCase(unittest.TestCase):
                 verify_urls.check_url(mock_dataset_uri, mock.Mock(), tries=1)
             mock_request.assert_called_once()
 
+    def test_check_url_ftp(self):
+        """Should convert FTP URLs to HTTP URLs, then send a HEAD
+        request
+        """
+        mock_dataset_uri = mock.Mock(id=1, uri='ftp://foo')
+        mock_response = mock.MagicMock(status_code=200, headers={})
+        with mock.patch('geospaas_harvesting.utils.http_request',
+                        return_value=mock_response) as mock_http_request:
+            self.assertTupleEqual(
+                verify_urls.check_url(mock_dataset_uri, None),
+                (True, 200, 1, 'ftp://foo'))
+            mock_http_request.assert_called_with(
+                'HEAD', 'http://foo', allow_redirects=True, auth=None)
+
     def test_read_config(self):
         """Should read the provider configuration from a YAML file"""
         config = textwrap.dedent('''---


### PR DESCRIPTION
Complete the `verify_urls` module so that it can check URLs for all our current providers reasonably quickly.
Among other things, these functionalities have been added:
- parallel processing for each provider + multi-threading
- authentication
- throttle the requests sent to a particular provider
- delete stale DatasetURIs based on the output file of the checking step