### PR TITLE
Mock HTTP calls in tests

### DIFF
--- a/tests/providers/test_resto.py
+++ b/tests/providers/test_resto.py
@@ -21,9 +21,10 @@ class RestoProviderTestCase(unittest.TestCase):
 
     def test_make_crawler(self):
         """Test creating a crawler from parameters"""
-        provider = providers_resto.RestoProvider(
-            name='test', url='https://datahub.creodias.eu',
-            username='user', password='pass')
+        with mock.patch('geospaas_harvesting.utils.http_request'):
+            provider = providers_resto.RestoProvider(
+                name='test', url='https://datahub.creodias.eu',
+                username='user', password='pass')
         parameters = {
             'collection': 'SENTINEL-1',
             'location': Polygon(((1, 2), (2, 3), (3, 4), (1, 2))),

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -22,9 +22,9 @@ class IngestionRecoveryTestCase(django.test.TestCase):
             'geospaas_harvesting.crawlers.CrawlerIterator.FAILED_INGESTIONS_PATH',
             self.tmp_dir.name
         ).start()
+        self.addCleanup(mock.patch.stopall)
 
     def tearDown(self):
-        self.addCleanup(mock.patch.stopall)
         self.tmp_dir = None
 
     def generate_recovery_file(self, exception_type, errors_count=1):


### PR DESCRIPTION
Resolves #139 

Also made a small fix in test_recovery: the mock cleanup was in the `tearDown()` method instead of `setUp()`.