### PR TITLE
Fix earthdata cmr download URL

### DIFF
--- a/geospaas_harvesting/providers/earthdata_cmr.py
+++ b/geospaas_harvesting/providers/earthdata_cmr.py
@@ -112,6 +112,14 @@ class EarthDataCMRCrawler(HTTPPaginatedAPICrawler):
 
         return request_parameters
 
+    def _find_download_url(self, entry):
+        """Return the first URL whose type is 'GET DATA'"""
+        urls = entry['umm']['RelatedUrls']
+        for url in urls:
+            if url.get('Type', '').lower() == 'get data':
+                return url['URL']
+        return urls[0]['URL']
+
     def _get_datasets_info(self, page):
         """Get dataset attributes from the current page and
         adds them to self._results.
@@ -119,7 +127,7 @@ class EarthDataCMRCrawler(HTTPPaginatedAPICrawler):
         entries = json.loads(page)['items']
 
         for entry in entries:
-            url = entry['umm']['RelatedUrls'][0]['URL']
+            url = self._find_download_url(entry)
             self.logger.debug("Adding '%s' to the list of resources.", url)
             self._results.append(DatasetInfo(url, entry))
 

--- a/tests/providers/test_earthdata_cmr.py
+++ b/tests/providers/test_earthdata_cmr.py
@@ -169,6 +169,32 @@ class EarthdataCMRCrawlerTestCase(unittest.TestCase):
                 }
             })
 
+    def test_find_download_url(self):
+        """Test finding a download URL in an entry"""
+        entry = {
+            'umm': {
+                'RelatedUrls': [
+                    {'URL': 'https://foo/bar.json', 'Type': 'EXTENDED METADATA'},
+                    {'URL': 'https://foo/bar.nc', 'Type': 'GET DATA'},
+                    {'URL': 'https://baz/bar.nc', 'Type': 'GET DATA'},
+                    {'URL': 'https://foo/qux.png', 'Type': 'DIRECT DOWNLOAD'},
+                ]
+            }
+        }
+        self.assertEqual(self.crawler._find_download_url(entry), 'https://foo/bar.nc')
+
+    def test_find_download_url_no_get_data(self):
+        """Test finding a download URL in an entry when no GET DATA type is available"""
+        entry = {
+            'umm': {
+                'RelatedUrls': [
+                    {'URL': 'https://foo/bar.nc', 'Type': 'DOWNLOAD'},
+                    {'URL': 'https://baz/bar.nc', 'Type': 'DOWNLOAD'},
+                ]
+            }
+        }
+        self.assertEqual(self.crawler._find_download_url(entry), 'https://foo/bar.nc')
+
     def test_get_datasets_info(self):
         """_get_datasets_info() should extract datasets information
         from a response page


### PR DESCRIPTION
Until now, the EarthDataCMRCrawler just selected the first URL it found.
The Earthdata CMR API can return several URL for one entry, some of which don't point to the data but to metadata, previews, etc.
The EarthDataCMRCrawler now selects the first URL of type "GET DATA", which should guarantee getting a download URL for the actual data.