### PR TITLE
CMEMS provider fixes for compatibility with SST_GLO_PHY_L4_NRT_010_043

### DIFF
--- a/geospaas_harvesting/providers/cmems.py
+++ b/geospaas_harvesting/providers/cmems.py
@@ -307,7 +307,7 @@ class CMEMSMetadataNormalizer():
             ),
             # generic 1 day coverage
             (
-                re.compile(rf'(^|[-_.:]){providers_utils.YEARMONTHDAY_REGEX}([-_.:T]|$)'),
+                re.compile(rf'(^|[-_.:]){providers_utils.YEARMONTHDAY_REGEX}(\d{{6}})?([-_.:T]|$)'),
                 lambda time: (time, time + relativedelta(days=1))
             ),
             # generic 1 month coverage

--- a/geospaas_harvesting/providers/cmems.py
+++ b/geospaas_harvesting/providers/cmems.py
@@ -122,8 +122,9 @@ class CMEMSCrawler(Crawler):
                 months_regex.append(f"{month:02d}({days_regex})")
 
             years_regex.append(f"({year}({'|'.join(months_regex)}))")
+            full_regex = '|'.join(years_regex)
 
-        return f".*_({'|'.join(years_regex)})_.*"
+        return f"^(.*_({full_regex})_.*)|({full_regex}.*)$"
 
     @staticmethod
     def _find_dict_in_list(dicts_list, key, value):

--- a/geospaas_harvesting/providers/cmems.py
+++ b/geospaas_harvesting/providers/cmems.py
@@ -377,10 +377,12 @@ class CMEMSMetadataNormalizer():
         variables = []
         variable_dict = None
         for variable in dataset_info.metadata['variables']:
-            if variable['standard_name']:
-                search_name = variable['standard_name']
-            elif variable['short_name']:
-                search_name = variable['short_name']
+            standard_name = variable.get('standard_name')
+            short_name = variable.get('short_name')
+            if standard_name:
+                search_name = standard_name
+            elif short_name:
+                search_name = short_name
             else:
                 self.logger.error('No available name for the following variable, skipping: %s',
                                   variable)

--- a/tests/providers/test_cmems.py
+++ b/tests/providers/test_cmems.py
@@ -58,38 +58,43 @@ class CMEMSCrawlerTestCase(unittest.TestCase):
         """Test making a regular expression matching a time range
         """
         mock_crawler = mock.Mock()
+        regex_template = "^(.*_({regex})_.*)|({regex}.*)$"
 
         mock_crawler.time_range = (datetime(2024, 9, 1),
                                    datetime(2024, 9, 2))
         self.assertEqual(
              CMEMSCrawler.make_filter(mock_crawler),
-             '.*_((2024(09(01|02))))_.*')
+             regex_template.format(regex='(2024(09(01|02)))'))
 
         mock_crawler.time_range = (datetime(2024, 9, 1),
                                    datetime(2024, 10, 15))
         self.assertEqual(
              CMEMSCrawler.make_filter(mock_crawler),
-             '.*_((2024(09(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24'
-             '|25|26|27|28|29|30)|10(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15))))_.*')
+             regex_template.format(regex=(
+                 '(2024(09(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23'
+                 '|24|25|26|27|28|29|30)|10(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15)))'
+             )))
 
         mock_crawler.time_range = (datetime(2024, 11, 1),
                                    datetime(2025, 1, 1))
         self.assertEqual(
              CMEMSCrawler.make_filter(mock_crawler),
-             '.*_((202412[0-3][0-9])|(2024(11(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|'
-             '18|19|20|21|22|23|24|25|26|27|28|29|30)))|(2025(01(01))))_.*')
+             regex_template.format(regex=(
+                    '(202412[0-3][0-9])|(2024(11(01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|'
+                    '16|17|18|19|20|21|22|23|24|25|26|27|28|29|30)))|(2025(01(01)))')))
 
         mock_crawler.time_range = (datetime(2023, 12, 30),
                                    datetime(2024, 1, 2))
         self.assertEqual(
              CMEMSCrawler.make_filter(mock_crawler),
-             '.*_((2023(12(30|31)))|(2024(01(01|02))))_.*')
+             regex_template.format(regex=('(2023(12(30|31)))|(2024(01(01|02)))')))
 
         mock_crawler.time_range = (datetime(2023, 12, 30),
                                    datetime(2025, 1, 2))
         self.assertEqual(
              CMEMSCrawler.make_filter(mock_crawler),
-             '.*_((2023(12(30|31)))|(2024[0-9]{4})|(2025(01(01|02))))_.*')
+             regex_template.format(regex=(
+                 '(2023(12(30|31)))|(2024[0-9]{4})|(2025(01(01|02)))')))
 
         mock_crawler.time_range = (None, None)
         self.assertIsNone(CMEMSCrawler.make_filter(mock_crawler))


### PR DESCRIPTION
- Fix crawler's date filter regex 
- Fix normalizer's date regex
- Support dataset variables which don't have a standard name defined