### PR TITLE
Updates for the OTC 2025

### DIFF
--- a/geospaas_harvesting/providers/cmems.py
+++ b/geospaas_harvesting/providers/cmems.py
@@ -302,8 +302,9 @@ class CMEMSMetadataNormalizer():
                 lambda time: (time, time + relativedelta(months=1))
             ),
             (
-                re.compile(rf'^mfwamglocep_{providers_utils.YEARMONTHDAY_REGEX}00_R[0-9]{{8}}'),
-                lambda time: (time, time + relativedelta(hours=24))
+                re.compile(rf'^mfwamglocep_{providers_utils.YEARMONTHDAY_REGEX}' +
+                           r'(?P<hour>(00|12))_R[0-9]{8}_(00|12)H'),
+                lambda time: (time, time + relativedelta(hours=12))
             ),
             (
                 re.compile(rf'^mercatorbiomer4v2r1_global_mean_{providers_utils.YEARMONTH_REGEX}$'),
@@ -349,7 +350,7 @@ class CMEMSMetadataNormalizer():
             *self._product_info['sources'],
         )
         platform = self._search_source('gcmd_platform', search_strings)
-        if platform['Category'] == 'Models':
+        if 'Models' in platform['Category']:
             instrument = pythesint.get_gcmd_instrument('Computer')
         else:
             instrument = self._search_source('gcmd_instrument', search_strings)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # For example, this is used to build the Docker image.
 
 # strict requirements
-metanorm @ git+https://github.com/nansencenter/metanorm@4.5.2
+metanorm @ git+https://github.com/nansencenter/metanorm@4.5.3.dev0
 pythesint==1.7.0
 
 # loose requirements

--- a/tests/providers/test_cmems.py
+++ b/tests/providers/test_cmems.py
@@ -449,9 +449,9 @@ class CMEMSMetadataNormalizerTestCase(unittest.TestCase):
             (datetime(2020, 11, 1, tzinfo=timezone.utc),
              datetime(2020, 12, 1, tzinfo=timezone.utc)))
         self.assertTupleEqual(
-            self.normalizer.get_time_coverage('mfwamglocep_2021020200_R20210203'),
-            (datetime(2021, 2, 2, tzinfo=timezone.utc),
-             datetime(2021, 2, 3, tzinfo=timezone.utc)))
+            self.normalizer.get_time_coverage('mfwamglocep_2025040100_R20250402_00H'),
+            (datetime(2025, 4, 1, tzinfo=timezone.utc),
+             datetime(2025, 4, 1, 12, tzinfo=timezone.utc)))
         self.assertTupleEqual(
             self.normalizer.get_time_coverage('mercatorbiomer4v2r1_global_mean_20230103'),
             (datetime(2023, 1, 3, tzinfo=timezone.utc),


### PR DESCRIPTION
- fix CMEMS 001_027 time coverage
- update metanorm version to allow unknown platform for Earthdata CMR datasets