### PR TITLE
HTMLDirectoryCrawler: do not follow external links

### DIFF
--- a/geospaas_harvesting/crawlers.py
+++ b/geospaas_harvesting/crawlers.py
@@ -559,6 +559,8 @@ class HTMLDirectoryCrawler(DirectoryCrawler):
         if not parent_path.endswith('/'):
             parent_path += '/'
         for path in paths:
+            if urlparse(path).scheme != '':
+                continue
             if path.startswith(parent_path):
                 result.append(path)
             else:

--- a/tests/test_generic_crawlers.py
+++ b/tests/test_generic_crawlers.py
@@ -713,7 +713,7 @@ class HTMLDirectoryCrawlerTestCase(unittest.TestCase):
         Should prepend all the paths with the parent_path, except if they already start with it
         """
         parent_path = '/foo'
-        paths = ['/foo/bar', 'baz']
+        paths = ['/foo/bar', 'baz', 'https://external/site']
         self.assertEqual(
             crawlers.HTMLDirectoryCrawler._prepend_parent_path(parent_path, paths),
             ['/foo/bar', '/foo/baz']


### PR DESCRIPTION
In HTMLDirectoryCrawler, only follow links relative to the current page, not full URLs