### PR TITLE
allow specifying date regex for raw normalizer

### DIFF
--- a/geospaas_harvesting/normalizers/raw.py
+++ b/geospaas_harvesting/normalizers/raw.py
@@ -1,18 +1,32 @@
 """Raw normalizers"""
+import re
+from datetime import datetime, timezone
+
 from .base import MetadataNormalizer
-from .utils import NC_H5_FILENAME_MATCHER
+from .utils import NC_H5_FILENAME_MATCHER, raises
+from ..utils import parse_timedelta_str
 
 
 class RawMetadataNormalizer(MetadataNormalizer):
     """No guess work, just create a Dataset with an entry_id and a URL
     and optionally add the raw metadata as a tag
+    Offers the possibility to specify a regex which will be applied to
+    the URL to find a time.
     """
 
     name = 'raw'
 
     def __init__(self, **kwargs):
+        """`time_regex`, if specified, should be a regex containing the
+        following named groups:
+        'year', 'month', 'day',         <- required
+        'hour', 'minute', 'second'      <- optional
+        The pattern will be matched against the full URL.
+        """
         super().__init__(**kwargs)
         self.save_raw_metadata = kwargs.get('save_raw_metadata', True)
+        self.time_regex = kwargs.get('time_regex', None)
+        self.time_offset = parse_timedelta_str(kwargs.get('time_offset', '1s'))
 
     def get_entry_id(self, dataset_info):
         filename_match = NC_H5_FILENAME_MATCHER.search(dataset_info.url)
@@ -21,10 +35,26 @@ class RawMetadataNormalizer(MetadataNormalizer):
         else:
             return None
 
+    @raises((AttributeError, KeyError))
     def get_time_coverage_start(self, dataset_info):
+        if self.time_regex is not None:
+            groups = re.match(self.time_regex, dataset_info.url).groupdict()
+            year = int(groups['year'])
+            month = int(groups['month'])
+            day = int(groups['day'])
+            hour = int(groups.get('hour', 0))
+            minute = int(groups.get('minute', 0))
+            second = int(groups.get('second', 0))
+            return datetime(
+                year=year,month=month,day=day,
+                hour=hour, minute=minute, second=second,
+                tzinfo=timezone.utc)
         return None
 
+    @raises((AttributeError, KeyError))
     def get_time_coverage_end(self, dataset_info):
+        if self.time_regex is not None:
+            return self.get_time_coverage_start(dataset_info) + self.time_offset
         return None
 
     def get_location_geometry(self, dataset_info):

--- a/geospaas_harvesting/utils.py
+++ b/geospaas_harvesting/utils.py
@@ -2,8 +2,10 @@
 import importlib
 import os
 import pkgutil
+import re
 import sys
 import xml.etree.ElementTree as ET
+from datetime import timedelta
 from urllib.parse import urlparse
 
 import requests
@@ -166,3 +168,16 @@ def merge_configs(config_dict: dict, override: dict):
         else:
             final_config[key] = override[key]
     return final_config
+
+
+def parse_timedelta_str(timedelta_str: str) -> timedelta:
+    """Parse a string in the format `?d?h?m?s`
+    """
+    groups = re.match(
+        r'((?P<days>\d+)d)?((?P<hours>\d+)h)?((?P<minutes>\d+)m)?((?P<seconds>\d+)s)?',
+        timedelta_str).groupdict()
+    return timedelta(
+        days=int(groups.get('days') or 0),
+        hours=int(groups.get('hours') or 0),
+        minutes=int(groups.get('minutes') or 0),
+        seconds=int(groups.get('seconds') or 0))

--- a/tests/normalizers/test_raw.py
+++ b/tests/normalizers/test_raw.py
@@ -1,5 +1,6 @@
 """Tests for the RawMetadataNormalizer"""
 import unittest
+from datetime import datetime, timezone
 
 import geospaas_harvesting.normalizers as normalizers
 from geospaas_harvesting.crawlers.base import DatasetInfo
@@ -29,6 +30,29 @@ class RawMetadataNormalizerTestCase(unittest.TestCase):
     def test_get_time_coverage_start(self):
         """Test getting the start of the time coverage"""
         self.assertIsNone(self.normalizer.get_time_coverage_start(DatasetInfo('')))
+
+    def test_get_time_coverage_with_regex(self):
+        """Test getting the the time coverage with a regex"""
+        n = normalizers.raw.RawMetadataNormalizer(
+            time_regex=r'.*/bar_(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}).nc',
+            time_offset='1d')
+        self.assertEqual(
+            n.get_time_coverage_start(DatasetInfo(url='https://foo/bar_20250502.nc')),
+            datetime(2025, 5, 2, tzinfo=timezone.utc))
+        self.assertEqual(
+            n.get_time_coverage_end(DatasetInfo(url='https://foo/bar_20250502.nc')),
+            datetime(2025, 5, 3, tzinfo=timezone.utc))
+
+        n = normalizers.raw.RawMetadataNormalizer(
+            time_regex=(r'.*/bar_(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})'
+                        r'T(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2})Z.nc'),
+            time_offset='1h')
+        self.assertEqual(
+            n.get_time_coverage_start(DatasetInfo(url='https://foo/bar_20250502T095612Z.nc')),
+            datetime(2025, 5, 2, 9, 56, 12, tzinfo=timezone.utc))
+        self.assertEqual(
+            n.get_time_coverage_end(DatasetInfo(url='https://foo/bar_20250502T095612Z.nc')),
+            datetime(2025, 5, 2, 10, 56, 12, tzinfo=timezone.utc))
 
     def test_get_time_coverage_end(self):
         """Test getting the end of the time coverage"""


### PR DESCRIPTION
Allow specifying date regex for raw normalizer to be able to have an indication of temporal coverage.