### PR TITLE
Add S3 URLs to S3 and STAC normalizers

### DIFF
--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -42,8 +42,8 @@ class Ingester():
         """Writes a dataset to the database based on its attributes and
         URL. The input should be a DatasetInfo object.
         """
-        dataset_kwargs, url, keywords, parameters, tags = to_ingest
-        dataset_status = dataset_uri_status = OperationStatus.NOOP
+        dataset_kwargs, urls, keywords, parameters, tags = to_ingest
+        dataset_status = OperationStatus.NOOP
 
         with django.db.transaction.atomic():
             if self.update:
@@ -63,10 +63,15 @@ class Ingester():
             elif self.update:
                 dataset_status = OperationStatus.UPDATED
 
-            dataset_uri, uri_created = DatasetURI.objects.get_or_create(uri=url, dataset=dataset)
-
-            if uri_created:
-                dataset_uri_status = OperationStatus.CREATED
+            created_uris = []
+            existing_uris = []
+            for url in urls:
+                dataset_uri, uri_created = DatasetURI.objects.get_or_create(uri=url,
+                                                                            dataset=dataset)
+                if uri_created:
+                    created_uris.append(dataset_uri)
+                else:
+                    existing_uris.append(dataset_uri)
 
             # add many-to-many relationships if the dataset was created
             # or update is True
@@ -82,7 +87,7 @@ class Ingester():
                     self.logger.debug("Adding tag %s to dataset %s", tag, dataset)
                     dataset.tags.add(tag)
 
-        return (dataset_uri.uri, dataset.entry_id, dataset_status, dataset_uri_status)
+        return (created_uris, existing_uris, dataset.entry_id, dataset_status)
 
     def ingest(self, elements_to_ingest):
         """Iterates over an iterator of Tuple[Dataset,DatasetURI] and
@@ -100,29 +105,19 @@ class Ingester():
                     futures.append(executor.submit(self._ingest_dataset, to_ingest))
                 for future in concurrent.futures.as_completed(futures):
                     try:
-                        url, dataset_entry_id, dataset_status, dataset_uri_status = future.result()
+                        (created_uris, existing_uris,
+                         dataset_entry_id, dataset_status) = future.result()
                         if dataset_status == OperationStatus.CREATED:
-                            self.logger.info("Successfully created dataset '%s' from url: '%s'",
-                                             dataset_entry_id, url)
-                            if dataset_uri_status == OperationStatus.NOOP:
-                                # This should only happen if a database problem
-                                # occurred in _ingest_dataset(), because the
-                                # presence of the URI in the database is checked
-                                # before attempting to ingest.
-                                self.logger.error(
-                                    "The Dataset URI '%s' was not created for dataset '%s'",
-                                    url, dataset_entry_id)
+                            message = f"Successfully created dataset '{dataset_entry_id}'"
                         elif dataset_status == OperationStatus.UPDATED:
-                            self.logger.info("Sucessfully updated dataset '%s' from url: '%s'",
-                                             dataset_entry_id, url)
+                            message = f"Successfully updated dataset '{dataset_entry_id}'"
                         elif dataset_status == OperationStatus.NOOP:
-                            if dataset_uri_status == OperationStatus.CREATED:
-                                self.logger.info("Dataset URI '%s' added to existing dataset '%s'",
-                                                 url, dataset_entry_id)
-                            elif dataset_uri_status == OperationStatus.NOOP:
-                                self.logger.info("Dataset '%s' with URI '%s' already exists",
-                                                 dataset_entry_id, url)
-
+                            message = f"Dataset already exists: {dataset_entry_id}"
+                        if created_uris:
+                            message += f". Created URIs: {[u.uri for u in created_uris]}"
+                        if existing_uris:
+                            message += f". URIs already exist: {[u.uri for u in existing_uris]}"
+                        self.logger.info(message)
                     except Exception as error:  # pylint: disable=broad-except
                         self.logger.error("Error during ingestion: %s", str(error), exc_info=True)
                     finally:

--- a/geospaas_harvesting/ingesters.py
+++ b/geospaas_harvesting/ingesters.py
@@ -112,7 +112,7 @@ class Ingester():
                         elif dataset_status == OperationStatus.UPDATED:
                             message = f"Successfully updated dataset '{dataset_entry_id}'"
                         elif dataset_status == OperationStatus.NOOP:
-                            message = f"Dataset already exists: {dataset_entry_id}"
+                            message = f"Dataset already exists: '{dataset_entry_id}'"
                         if created_uris:
                             message += f". Created URIs: {[u.uri for u in created_uris]}"
                         if existing_uris:

--- a/geospaas_harvesting/normalizers/base.py
+++ b/geospaas_harvesting/normalizers/base.py
@@ -62,7 +62,8 @@ class MetadataNormalizer():
         keywords = self.get_keywords(dataset_info)
         parameters = self.get_dataset_parameters(dataset_info)
         tags_kwargs = self._get_all_tags(dataset_info)
-        return (dataset_kwargs, dataset_info.url, keywords, parameters, tags_kwargs)
+        extra_urls = self.get_extra_urls(dataset_info)
+        return (dataset_kwargs, [dataset_info.url, *extra_urls], keywords, parameters, tags_kwargs)
 
     def normalize_stream(self, dataset_infos):
         """Normalize an iterable of DatasetInfo objects.
@@ -127,6 +128,12 @@ class MetadataNormalizer():
             return utils.create_parameter_list(dataset_info.metadata['raw_dataset_parameters'])
         except KeyError:
             return []
+
+    def get_extra_urls(self, dataset_info):
+        """Get extra URLs for the dataset (for example alternative
+        download URLs)
+        """
+        return []
 
 
 class Stop():

--- a/geospaas_harvesting/normalizers/odata.py
+++ b/geospaas_harvesting/normalizers/odata.py
@@ -54,3 +54,11 @@ class ODataMetadataNormalizer(MetadataNormalizer):
     @utils.raises(KeyError)
     def get_location_geometry(self, dataset_info):
         return shapely.to_wkt(shapely.geometry.shape(dataset_info.metadata['GeoFootprint']))
+
+    def get_extra_urls(self, dataset_info):
+        urls = []
+        try:
+            urls.append(f"s3://{dataset_info.metadata['S3Path'].lstrip('/')}")
+        except KeyError:
+            pass
+        return urls

--- a/geospaas_harvesting/normalizers/stac.py
+++ b/geospaas_harvesting/normalizers/stac.py
@@ -78,8 +78,8 @@ class STACMetadataNormalizer(MetadataNormalizer):
             shapely.from_geojson(json.dumps(dataset_info.metadata['geometry'])))
 
     def get_extra_urls(self, dataset_info):
-        s3_url = None
-        for link in dataset_info.metadata.get('links'):
+        extra_urls = []
+        for link in dataset_info.metadata.get('links', []):
             if 's3' in link.get('auth:refs', []):
-                s3_url = link.get('href')
-        return [s3_url]
+                extra_urls.append(link.get('href'))
+        return extra_urls

--- a/geospaas_harvesting/normalizers/stac.py
+++ b/geospaas_harvesting/normalizers/stac.py
@@ -76,3 +76,10 @@ class STACMetadataNormalizer(MetadataNormalizer):
     def get_location_geometry(self, dataset_info):
         return shapely.to_wkt(
             shapely.from_geojson(json.dumps(dataset_info.metadata['geometry'])))
+
+    def get_extra_urls(self, dataset_info):
+        s3_url = None
+        for link in dataset_info.metadata.get('links'):
+            if 's3' in link.get('auth:refs', []):
+                s3_url = link.get('href')
+        return [s3_url]

--- a/tests/normalizers/test_base.py
+++ b/tests/normalizers/test_base.py
@@ -86,6 +86,10 @@ class MetadataNormalizerTestCase(unittest.TestCase):
         """
         self.assertListEqual(self.normalizer.get_dataset_parameters(DatasetInfo('')), [])
 
+    def test_get_extra_urls(self):
+        """Should return an empty list by default"""
+        self.assertListEqual(self.normalizer.get_extra_urls(DatasetInfo('')), [])
+
     def test_normalize(self):
         """Test that the normalize method returns the right attributes
         """
@@ -131,6 +135,9 @@ class MetadataNormalizerTestCase(unittest.TestCase):
             def get_tags(self, dataset_info):
                 return [{'name': 'collection', 'value': 'test'}]
 
+            def get_extra_urls(self, dataset_info):
+                return ['https://dl.foo']
+
         self.assertTupleEqual(
             TestNormalizer().normalize(DatasetInfo('https://foo')),
             (
@@ -142,7 +149,7 @@ class MetadataNormalizerTestCase(unittest.TestCase):
                     'time_coverage_start': 'time_coverage_start',
                     'time_coverage_end': 'time_coverage_end',
                 },
-                'https://foo',
+                ['https://foo', 'https://dl.foo'],
                 [{'kind': 'gcmd_instrument', 'data': {'Short_Name': 'instrument'}}],
                 ['dataset_parameters'],
                 [{'name': 'collection', 'value': 'test'}],
@@ -164,7 +171,7 @@ class MetadataNormalizerTestCase(unittest.TestCase):
                     'time_coverage_start': 'force_time_coverage_start',
                     'time_coverage_end': 'force_time_coverage_end',
                 },
-                'https://foo',
+                ['https://foo', 'https://dl.foo'],
                 [{'kind': 'gcmd_instrument', 'data': {'Short_Name': 'instrument'}}],
                 ['dataset_parameters'],
                 [{'name': 'collection', 'value': 'test'}],

--- a/tests/normalizers/test_odata.py
+++ b/tests/normalizers/test_odata.py
@@ -112,3 +112,12 @@ class ODataMetadataNormalizerTestCase(unittest.TestCase):
         """An exception must be raised if the attribute is missing"""
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry(DatasetInfo(''))
+
+    def test_get_extra_urls(self):
+        """Test getting the S3 URL"""
+        self.assertListEqual(
+            self.normalizer.get_extra_urls(DatasetInfo('https://foo', {'S3Path': 'bar/baz'})),
+            ['s3://bar/baz'])
+        self.assertListEqual(
+            self.normalizer.get_extra_urls(DatasetInfo('https://foo', {})),
+            [])

--- a/tests/normalizers/test_stac.py
+++ b/tests/normalizers/test_stac.py
@@ -155,3 +155,14 @@ class STACMetadataNormalizerTestCase(unittest.TestCase):
         """An exception must be raised if the attribute is missing"""
         with self.assertRaises(MetadataNormalizationError):
             self.normalizer.get_location_geometry(DatasetInfo(''))
+
+    def test_get_extra_urls(self):
+        """Test getting the S3 URL from metadata"""
+        self.assertListEqual(self.normalizer.get_extra_urls(DatasetInfo('', {})), [])
+        self.assertListEqual(self.normalizer.get_extra_urls(DatasetInfo('', {'links': []})), [])
+        self.assertListEqual(
+            self.normalizer.get_extra_urls(DatasetInfo('', {'links': [{'a': 'b'}]})), [])
+        self.assertListEqual(
+            self.normalizer.get_extra_urls(DatasetInfo('', {'links': [{'auth:refs': ['s3'],
+                                                            'href': 's3://bucket/folder/'}]})),
+            ['s3://bucket/folder/'])

--- a/tests/test_ingesters.py
+++ b/tests/test_ingesters.py
@@ -112,12 +112,14 @@ class IngesterTestCase(django.test.TransactionTestCase):
 
     def test_ingest_same_uri_twice(self):
         """Ingestion of the same URI must not create duplicates"""
-        to_ingest = ({'entry_id': 'foo'}, 'https://bar/foo.nc', [], [], [])
+        uri = 'https://bar/foo.nc'
+        to_ingest = ({'entry_id': 'foo'}, [uri], [], [], [])
         self.ingester._ingest_dataset(to_ingest)
-        _, _, dataset_status, dataset_uri_status = self.ingester._ingest_dataset(to_ingest)
+        created_uris, existing_uris, _, dataset_status = self.ingester._ingest_dataset(to_ingest)
 
         self.assertEqual(dataset_status, ingesters.OperationStatus.NOOP)
-        self.assertEqual(dataset_uri_status, ingesters.OperationStatus.NOOP)
+        self.assertListEqual(created_uris, [])
+        self.assertListEqual(existing_uris, [DatasetURI.objects.get(uri=uri)])
         self.assertEqual(Dataset.objects.count(), 1)
 
     def test_ingest_same_dataset_different_uri(self):
@@ -126,7 +128,7 @@ class IngesterTestCase(django.test.TransactionTestCase):
                 'http://test.uri2/dataset']
 
         for uri in uris:
-            self.ingester._ingest_dataset(({'entry_id': 'foo'}, uri, [], [], []))
+            self.ingester._ingest_dataset(({'entry_id': 'foo'}, [uri], [], [], []))
 
         self.assertEqual(Dataset.objects.count(), 1)
         self.assertEqual(DatasetURI.objects.count(), 2)
@@ -140,16 +142,17 @@ class IngesterTestCase(django.test.TransactionTestCase):
         uri = 'http://test.uri/dataset'
         entry_id = 'foo'
         tag_kwargs = {'name': 'custom_tag', 'value': 'hello'}
-        to_ingest = ({'entry_id': entry_id}, uri, [], [], [])
+        to_ingest = ({'entry_id': entry_id}, [uri], [], [], [])
         to_ingest_update = (
-            {'entry_id': entry_id, 'entry_title': 'bar'}, uri, [], [], [tag_kwargs])
+            {'entry_id': entry_id, 'entry_title': 'bar'}, [uri], [], [], [tag_kwargs])
 
         ingester = ingesters.Ingester(update=True)
         ingester._ingest_dataset(to_ingest)
-        _, _, dataset_status, dataset_uri_status = ingester._ingest_dataset(to_ingest_update)
+        created_uris, existing_uris, _, dataset_status = ingester._ingest_dataset(to_ingest_update)
 
         self.assertEqual(dataset_status, ingesters.OperationStatus.UPDATED)
-        self.assertEqual(dataset_uri_status, ingesters.OperationStatus.NOOP)
+        self.assertListEqual(created_uris, [])
+        self.assertListEqual(existing_uris, [DatasetURI.objects.get(uri=uri)])
         self.assertEqual(Dataset.objects.count(), 1)
         dataset = Dataset.objects.get(entry_id=entry_id)
         self.assertEqual(dataset.entry_id, 'foo')
@@ -158,19 +161,21 @@ class IngesterTestCase(django.test.TransactionTestCase):
 
     def test_ingest_no_entry_id(self):
         """Test ingesting a dataset when no entry_id is provided"""
-        uri, entry_id, dataset_status, uri_status = self.ingester._ingest_dataset(( # pylint: disable=protected-access
-            {'entry_title': 'qux'}, 'https://bar/foo.nc', [], [], []))
-        self.assertEqual(uri, 'https://bar/foo.nc')
-        self.assertIsInstance(entry_id, uuid.UUID)
+        uri = 'https://bar/foo.nc'
+        created_uris, existing_uris, dataset_entry_id, dataset_status = (
+            self.ingester._ingest_dataset(( # pylint: disable=protected-access
+                {'entry_title': 'qux'}, [uri], [], [], [])))
+        self.assertListEqual(created_uris, [DatasetURI.objects.get(uri=uri)])
+        self.assertListEqual(existing_uris, [])
+        self.assertIsInstance(dataset_entry_id, uuid.UUID)
         self.assertEqual(dataset_status, ingesters.OperationStatus.CREATED)
-        self.assertEqual(uri_status, ingesters.OperationStatus.CREATED)
 
     def test_log_on_ingestion_error(self):
         """The cause of the error must be logged if an exception is raised while ingesting"""
         with mock.patch.object(ingesters.Ingester, '_ingest_dataset') as mock_ingest_dataset:
             mock_ingest_dataset.side_effect = TypeError('error message')
             with self.assertLogs(self.ingester.logger, level=logging.ERROR) as logger_cm:
-                self.ingester.ingest([({'entry_id': 'foo'}, 'uri', [], [], [])])
+                self.ingester.ingest([({'entry_id': 'foo'}, ['uri'], [], [], [])])
             self.assertEqual(logger_cm.records[0].message,
                              "Error during ingestion: error message")
             self.assertIs(logger_cm.records[0].exc_info[0], TypeError)
@@ -179,43 +184,43 @@ class IngesterTestCase(django.test.TransactionTestCase):
         """All ingestion successes must be logged"""
         with mock.patch.object(ingesters.Ingester, '_ingest_dataset') as mock_ingest_dataset:
             mock_ingest_dataset.return_value = (
-                'uri',
+                [mock.Mock(uri='uri')],
+                [],
                 'foo',
                 ingesters.OperationStatus.CREATED,
-                ingesters.OperationStatus.CREATED
             )
             with self.assertLogs(self.ingester.logger, level=logging.INFO) as logger_cm:
-                self.ingester.ingest([({'entry_id': 'foo'}, 'uri', [], [], [])])
+                self.ingester.ingest([({'entry_id': 'foo'}, ['uri'], [], [], [])])
                 self.assertEqual(logger_cm.records[0].message,
-                                 "Successfully created dataset 'foo' from url: 'uri'")
+                                 "Successfully created dataset 'foo'. Created URIs: ['uri']")
 
     def test_log_on_update(self):
         """Test logging a successful update"""
         with mock.patch.object(ingesters.Ingester, '_ingest_dataset') as mock_ingest_dataset:
             mock_ingest_dataset.return_value = (
-                'uri',
+                [],
+                [mock.Mock(uri='uri')],
                 'foo',
                 ingesters.OperationStatus.UPDATED,
-                ingesters.OperationStatus.NOOP
             )
             with self.assertLogs(self.ingester.logger, level=logging.INFO) as logger_cm:
-                self.ingester.ingest([({'entry_id': 'foo'}, 'uri', [], [], [])])
+                self.ingester.ingest([({'entry_id': 'foo'}, ['uri'], [], [], [])])
                 self.assertEqual(logger_cm.records[0].message,
-                                 "Sucessfully updated dataset 'foo' from url: 'uri'")
+                                 "Successfully updated dataset 'foo'. URIs already exist: ['uri']")
 
     def test_log_existing_dataset(self):
         """Test logging a successful update"""
         with mock.patch.object(ingesters.Ingester, '_ingest_dataset') as mock_ingest_dataset:
             mock_ingest_dataset.return_value = (
-                'uri',
+                [],
+                [mock.Mock(uri='uri')],
                 'foo',
                 ingesters.OperationStatus.NOOP,
-                ingesters.OperationStatus.NOOP
             )
             with self.assertLogs(self.ingester.logger, level=logging.INFO) as logger_cm:
-                self.ingester.ingest([({'entry_id': 'foo'}, 'uri', [], [], [])])
+                self.ingester.ingest([({'entry_id': 'foo'}, ['uri'], [], [], [])])
                 self.assertEqual(logger_cm.records[0].message,
-                                 "Dataset 'foo' with URI 'uri' already exists")
+                                 "Dataset already exists: 'foo'. URIs already exist: ['uri']")
 
     def test_log_on_ingestion_same_dataset_different_uri(self):
         """A message must be logged when a URI is added to an existing
@@ -223,32 +228,15 @@ class IngesterTestCase(django.test.TransactionTestCase):
         """
         with mock.patch.object(ingesters.Ingester, '_ingest_dataset') as mock_ingest_dataset:
             mock_ingest_dataset.return_value = (
-                'uri',
+                [mock.Mock(uri='uri')],
+                [],
                 'foo',
                 ingesters.OperationStatus.NOOP,
-                ingesters.OperationStatus.CREATED
             )
             with self.assertLogs(self.ingester.logger, level=logging.INFO) as logger_cm:
-                self.ingester.ingest([({'entry_id': 'foo'}, 'uri', [], [], [])])
+                self.ingester.ingest([({'entry_id': 'foo'}, ['uri'], [], [], [])])
                 self.assertEqual(logger_cm.records[0].message,
-                                 "Dataset URI 'uri' added to existing dataset 'foo'")
-
-    def test_log_error_on_dataset_created_with_existing_uri(self):
-        """
-        An error must be logged if a dataset is created during ingestion, even if its URI already
-        exists in the database (this should not be possible)
-        """
-        with mock.patch.object(ingesters.Ingester, '_ingest_dataset') as mock_ingest_dataset:
-            mock_ingest_dataset.return_value = (
-                'uri',
-                'foo',
-                ingesters.OperationStatus.CREATED,
-                ingesters.OperationStatus.NOOP
-            )
-            with self.assertLogs(self.ingester.logger, level=logging.WARNING) as logger_cm:
-                self.ingester.ingest([({'entry_id': 'foo'}, 'uri', [], [], [])])
-            self.assertEqual(logger_cm.records[0].message,
-                             "The Dataset URI 'uri' was not created for dataset 'foo'")
+                                 "Dataset already exists: 'foo'. Created URIs: ['uri']")
 
     def test_keyboard_interruption(self):
         """Test that keyboard interrupts are managed properly"""


### PR DESCRIPTION
- allow the Ingester to add more than one DatasetURI per Dataset
- allow normalizers to return extra URLs
- add S3 URLs to odata and STAC normalizers